### PR TITLE
Use function, not arrow function, to stay compatible with older node …

### DIFF
--- a/createjs.js
+++ b/createjs.js
@@ -1,4 +1,4 @@
-module.exports = (srcLng, trgLng, srcKeys, trgKeys, ns, cb) => {
+module.exports = function(srcLng, trgLng, srcKeys, trgKeys, ns, cb) {
   const js = {
     sourceLanguage: srcLng,
     targetLanguage: trgLng,
@@ -8,7 +8,7 @@ module.exports = (srcLng, trgLng, srcKeys, trgKeys, ns, cb) => {
   if (ns && typeof ns === 'string') {
     js.resources[ns] = {};
 
-    Object.keys(trgKeys).forEach((srcKey) => {
+    Object.keys(trgKeys).forEach(function(srcKey) {
       js.resources[ns][srcKey] = {
         source: srcKeys[srcKey],
         target: trgKeys[srcKey]
@@ -25,10 +25,10 @@ module.exports = (srcLng, trgLng, srcKeys, trgKeys, ns, cb) => {
     ns = null;
   }
 
-  Object.keys(trgKeys).forEach((ns) => {
+  Object.keys(trgKeys).forEach(function(ns) {
     js.resources[ns] = {};
 
-    Object.keys(trgKeys[ns]).forEach((srcKey) => {
+    Object.keys(trgKeys[ns]).forEach(function(srcKey) {
       js.resources[ns][srcKey] = {
         source: srcKeys[ns][srcKey],
         target: trgKeys[ns][srcKey]

--- a/createxliff.js
+++ b/createxliff.js
@@ -1,13 +1,13 @@
 const createjs = require('./createjs');
 const js2xliff = require('./js2xliff');
 
-module.exports = (srcLng, trgLng, srcKeys, trgKeys, ns, cb) => {
+module.exports = function(srcLng, trgLng, srcKeys, trgKeys, ns, cb) {
   if (!ns || typeof ns !== 'string') {
     cb = ns;
     ns = null;
   }
 
-  createjs(srcLng, trgLng, srcKeys, trgKeys, ns, (err, res) => {
+  createjs(srcLng, trgLng, srcKeys, trgKeys, ns, function(err, res) {
     if (err) return cb(err);
     js2xliff(res, cb);
   });

--- a/js2xliff.js
+++ b/js2xliff.js
@@ -25,7 +25,7 @@ function js2xliff(obj, opt, cb) {
     file: []
   };
 
-  Object.keys(obj.resources).forEach((nsName) => {
+  Object.keys(obj.resources).forEach(function(nsName) {
     const f = {
       $: {
         id: nsName
@@ -34,7 +34,7 @@ function js2xliff(obj, opt, cb) {
     };
     xmlJs.file.push(f);
 
-    Object.keys(obj.resources[nsName]).forEach((k) => {
+    Object.keys(obj.resources[nsName]).forEach(function(k) {
       const u = {
         $: {
           id: k

--- a/ofjs.js
+++ b/ofjs.js
@@ -1,23 +1,23 @@
-module.exports = (js, what, cb) => {
+module.exports = function(js, what, cb) {
   const res = {};
 
   const nsKeys = Object.keys(js.resources);
   if (nsKeys.length === 1) {
     const ns = js.resources[nsKeys[0]];
     const keys = Object.keys(ns);
-    keys.forEach((key) => {
+    keys.forEach(function(key) {
       res[key] = ns[key][what];
     });
     if (cb) cb(null, res);
     return res;
   }
 
-  nsKeys.forEach((nsKey) => {
+  nsKeys.forEach(function(nsKey) {
     res[nsKey] = {};
 
     const ns = js.resources[nsKey];
     const keys = Object.keys(ns);
-    keys.forEach((key) => {
+    keys.forEach(function(key) {
       res[nsKey][key] = ns[key][what];
     });
   });

--- a/sourceOfjs.js
+++ b/sourceOfjs.js
@@ -1,3 +1,3 @@
 const ofjs = require('./ofjs');
 
-module.exports = (js, cb) => ofjs(js, 'source', cb);
+module.exports = function(js, cb) {ofjs(js, 'source', cb);};

--- a/targetOfjs.js
+++ b/targetOfjs.js
@@ -1,3 +1,3 @@
 const ofjs = require('./ofjs');
 
-module.exports = (js, cb) => ofjs(js, 'target', cb);
+module.exports = function(js, cb) {ofjs(js, 'target', cb);};

--- a/test/test.js
+++ b/test/test.js
@@ -2,136 +2,159 @@ const expect = require('expect.js');
 const fixtures = require('./fixtures');
 
 function test(what, t) {
-  describe(what, () => {
+  describe(what, function() {
     it('index', t(require('../')[what]));
     it('direct', t(require('../' + what)));
   });
 }
 
-describe('single', () => {
+describe('single', function() {
 
-  test('xliff2js', (fn) => (done) => {
-    fn(fixtures.example.xliff, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example.js);
-      done();
-    });
+  test('xliff2js', function(fn) {
+    return function(done) {
+      return fn(fixtures.example.xliff, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example.js);
+        done();
+      });
+    };
   });
 
-  test('js2xliff', (fn) => (done) => {
-    fn(fixtures.example.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example.xliff);
-      done();
-    });
+  test('js2xliff', function(fn) {
+    return function(done) {
+      return fn(fixtures.example.js, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example.xliff);
+        done();
+      });
+    };
   });
 
-  test('targetOfjs', (fn) => (done) => {
-    fn(fixtures.example.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].target);
-      done();
-    });
+  test('targetOfjs', function(fn) {
+    return function(done) {
+      return fn(fixtures.example.js, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].target);
+        done();
+      });
+    };
   });
 
-  test('sourceOfjs', (fn) => (done) => {
-    fn(fixtures.example.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].source);
-      done();
-    });
+  test('sourceOfjs', function(fn) {
+    return function(done) {
+      return fn(fixtures.example.js, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].source);
+        done();
+      });
+    };
   });
 
-  test('createjs', (fn) => (done) => {
-    fn(fixtures.example.js.sourceLanguage,
-       fixtures.example.js.targetLanguage,
-       fixtures.example.js_source,
-       fixtures.example.js_target,
-       'namespace1',
-       (err, res) => {
-         expect(err).not.to.be.ok();
-         expect(res).to.eql(fixtures.example.js);
-         done();
-       }
-    );
+  test('createjs', function(fn) {
+    return function(done) {
+      return fn(fixtures.example.js.sourceLanguage,
+        fixtures.example.js.targetLanguage,
+        fixtures.example.js_source,
+        fixtures.example.js_target,
+        'namespace1',
+        function(err, res) {
+          expect(err).not.to.be.ok();
+          expect(res).to.eql(fixtures.example.js);
+          done();
+        }
+      );
+    };
   });
 
-  test('createxliff', (fn) => (done) => {
-    fn(fixtures.example.js.sourceLanguage,
-       fixtures.example.js.targetLanguage,
-       fixtures.example.js_source,
-       fixtures.example.js_target,
-       'namespace1',
-       (err, res) => {
-         expect(err).not.to.be.ok();
-         expect(res).to.eql(fixtures.example.xliff);
-         done();
-       }
-    );
+  test('createxliff', function(fn) {
+    return function(done) {
+      return fn(fixtures.example.js.sourceLanguage,
+          fixtures.example.js.targetLanguage,
+          fixtures.example.js_source,
+          fixtures.example.js_target,
+          'namespace1',
+          function(err, res) {
+            expect(err).not.to.be.ok();
+            expect(res).to.eql(fixtures.example.xliff);
+            done();
+          }
+      );
+    };
   });
 
 });
 
-describe('multi', () => {
-
-  test('xliff2js', (fn) => (done) => {
-    fn(fixtures.example_multi.xliff, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_multi.js);
-      done();
-    });
+describe('multi', function() {
+  test('xliff2js', function(fn) {
+    return function(done) {
+      return fn(fixtures.example_multi.xliff, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_multi.js);
+        done();
+      });
+    };
   });
 
-  test('js2xliff', (fn) => (done) => {
-    fn(fixtures.example_multi.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_multi.xliff);
-      done();
-    });
+  test('js2xliff', function(fn) {
+    return function(done) {
+      return fn(fixtures.example_multi.js, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_multi.xliff);
+        done();
+      });
+    };
   });
 
-  test('targetOfjs', (fn) => (done) => {
-    fn(fixtures.example_multi.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].target);
-      expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].target);
-      done();
-    });
+  test('targetOfjs', function(fn) {
+    return function(done) {
+      return fn(fixtures.example_multi.js, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].target);
+        expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].target);
+        done();
+      });
+    };
   });
 
-  test('sourceOfjs', (fn) => (done) => {
-    fn(fixtures.example_multi.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].source);
-      expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].source);
-      done();
-    });
+  test('sourceOfjs', function(fn) {
+    return function(done) {
+      return fn(fixtures.example_multi.js, function(err, res) {
+        expect(err).not.to.be.ok();
+        expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].source);
+        expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].source);
+        done();
+      });
+    };
   });
 
-  test('createjs', (fn) => (done) => {
-    fn(fixtures.example_multi.js.sourceLanguage,
-       fixtures.example_multi.js.targetLanguage,
-       fixtures.example_multi.js_source,
-       fixtures.example_multi.js_target,
-       (err, res) => {
-         expect(err).not.to.be.ok();
-         expect(res).to.eql(fixtures.example_multi.js);
-         done();
-       }
-    );
+  test('createjs', function(fn) {
+    return function(done) {
+      return fn(fixtures.example_multi.js.sourceLanguage,
+        fixtures.example_multi.js.targetLanguage,
+        fixtures.example_multi.js_source,
+        fixtures.example_multi.js_target,
+        function(err, res) {
+          expect(err).not.to.be.ok();
+          expect(res).to.eql(fixtures.example_multi.js);
+          done();
+        }
+      );
+    };
   });
 
-  test('createxliff', (fn) => (done) => {
-    fn(fixtures.example_multi.js.sourceLanguage,
-       fixtures.example_multi.js.targetLanguage,
-       fixtures.example_multi.js_source,
-       fixtures.example_multi.js_target,
-       (err, res) => {
-         expect(err).not.to.be.ok();
-         expect(res).to.eql(fixtures.example_multi.xliff);
-         done();
-       }
-    );
+  test('createxliff', function(fn) {
+    return function(done) {
+      return fn(fixtures.example_multi.js.sourceLanguage,
+        fixtures.example_multi.js.targetLanguage,
+        fixtures.example_multi.js_source,
+        fixtures.example_multi.js_target,
+        function(err, res) {
+          expect(err).not.to.be.ok();
+          expect(res).to.eql(fixtures.example_multi.xliff);
+          done();
+        }
+      );
+    };
   });
 
 });

--- a/xliff2js.js
+++ b/xliff2js.js
@@ -10,7 +10,7 @@ function xliffToJs(str, cb) {
     resources: {}
   };
 
-  parser.parseString(str, (err, data) => {
+  parser.parseString(str, function(err, data) {
     if (err) return cb(err);
 
     const srcLang = data.xliff.$.srcLang;
@@ -19,18 +19,18 @@ function xliffToJs(str, cb) {
     result.sourceLanguage = srcLang;
     result.targetLanguage = trgLang;
 
-    data.xliff.file.forEach((f) => {
+    data.xliff.file.forEach(function(f) {
       const namespace = f.$.id;
       result.resources[namespace] = {};
 
       const entries = f.unit;
-      entries.forEach((entry) => {
+      entries.forEach(function(entry) {
         const key = entry.$.id;
         result.resources[namespace][key] = {
           source: '',
           target: ''
         };
-        entry.segment.forEach((seg) => {
+        entry.segment.forEach(function(seg) {
           if (seg.source) {
             const srcValue = seg.source[0];
             result.resources[namespace][key].source = srcValue;


### PR DESCRIPTION
I tried to run on a Ubuntu 14.04 machine, and it worked only after these changes.

```
$ node -v
v0.12.17
