### PR TITLE
Fix: Allow source and target nodes to contain attributes - XLIFF 1.2

### DIFF
--- a/test/fixtures/example12.xliff
+++ b/test/fixtures/example12.xliff
@@ -2,16 +2,16 @@
   <file original="namespace1">
     <body>
       <trans-unit id="key1">
-        <source>Hello</source>
-        <target>Hallo</target>
+        <source xml:lang="en-US">Hello</source>
+        <target xml:lang="de-CH">Hallo</target>
       </trans-unit>
       <trans-unit id="key2">
-        <source>An application to manipulate and process XLIFF documents</source>
-        <target>Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
+        <source xml:lang="en-US">An application to manipulate and process XLIFF documents</source>
+        <target xml:lang="de-CH">Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
       </trans-unit>
       <trans-unit id="key.nested">
-        <source>XLIFF Data Manager</source>
-        <target>XLIFF Daten Manager</target>
+        <source xml:lang="en-US">XLIFF Data Manager</source>
+        <target xml:lang="de-CH">XLIFF Daten Manager</target>
       </trans-unit>
     </body>
   </file>

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -10,6 +10,10 @@ function xliff12ToJs(str, cb) {
     resources: {}
   };
 
+  const extractValue = (value) => {
+    return typeof value !== 'string' ? value['_'] : value;
+  };
+
   parser.parseString(str, (err, data) => {
     if (err) return cb(err);
 
@@ -32,11 +36,11 @@ function xliff12ToJs(str, cb) {
         };
 
         if (entry.source) {
-          result.resources[namespace][key].source = entry.source[0];
+          result.resources[namespace][key].source = extractValue(entry.source[0]);
         }
 
         if (entry.target) {
-          result.resources[namespace][key].target = entry.target[0];
+          result.resources[namespace][key].target = extractValue(entry.target[0]);
         }
       });
     });


### PR DESCRIPTION
Found an issue when parsing a XLIFF 1.2 file from a translation service.  Need to handle the case of source or target nodes containing attributes (as well as not having any).