### PR TITLE
add support for <note> elements inside <trans-unit>

### DIFF
--- a/js2xliff.js
+++ b/js2xliff.js
@@ -41,7 +41,8 @@ function js2xliff(obj, opt, cb) {
         },
         segment: {
           source: obj.resources[nsName][k].source,
-          target: obj.resources[nsName][k].target
+          target: obj.resources[nsName][k].target,
+          note: obj.resources[nsName][k].note
         }
       };
       f.unit.push(u);

--- a/js2xliff.js
+++ b/js2xliff.js
@@ -35,15 +35,18 @@ function js2xliff(obj, opt, cb) {
     xmlJs.file.push(f);
 
     Object.keys(obj.resources[nsName]).forEach((k) => {
+      const segment = {
+        source: obj.resources[nsName][k].source,
+        target: obj.resources[nsName][k].target
+      };
+      if ('note' in obj.resources[nsName][k]) {
+        segment.note = obj.resources[nsName][k].note;
+      }
       const u = {
         $: {
           id: k
         },
-        segment: {
-          source: obj.resources[nsName][k].source,
-          target: obj.resources[nsName][k].target,
-          note: obj.resources[nsName][k].note
-        }
+        segment
       };
       f.unit.push(u);
     });

--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -47,7 +47,8 @@ function jsToXliff12(obj, opt, cb) {
           id: k
         },
         source: obj.resources[nsName][k].source,
-        target: obj.resources[nsName][k].target
+        target: obj.resources[nsName][k].target,
+        note: obj.resources[nsName][k].note
       };
       f.body['trans-unit'].push(u);
     });

--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -48,8 +48,10 @@ function jsToXliff12(obj, opt, cb) {
         },
         source: obj.resources[nsName][k].source,
         target: obj.resources[nsName][k].target,
-        note: obj.resources[nsName][k].note
       };
+      if ('note' in obj.resources[nsName][k]) {
+        u.note = obj.resources[nsName][k].note;
+      }
       f.body['trans-unit'].push(u);
     });
   });

--- a/test/fixtures/example_note.json
+++ b/test/fixtures/example_note.json
@@ -1,0 +1,30 @@
+{
+  "resources": {
+    "namespace1": {
+      "key1": {
+        "source": "Hello",
+        "target": "Hallo",
+        "note": "Hello note"
+      },
+      "key2": {
+        "source": "An application to manipulate and process XLIFF documents",
+        "target": "Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten",
+        "note": "Description note"
+      },
+      "key.nested": {
+        "source": "XLIFF Data Manager",
+        "target": "XLIFF Daten Manager",
+        "note": "Nested note"
+      }
+    },
+    "namespace2": {
+      "k": {
+        "source": "v",
+        "target": "v2",
+        "note": "n"
+      }
+    }
+  },
+  "sourceLanguage": "en-US",
+  "targetLanguage": "de-CH"
+}

--- a/test/fixtures/example_note.xliff
+++ b/test/fixtures/example_note.xliff
@@ -1,0 +1,34 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="de-CH">
+  <file id="namespace1">
+    <unit id="key1">
+      <segment>
+        <source>Hello</source>
+        <target>Hallo</target>
+        <note>Hello note</note>
+      </segment>
+    </unit>
+    <unit id="key2">
+      <segment>
+        <source>An application to manipulate and process XLIFF documents</source>
+        <target>Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
+        <note>Description note</note>
+      </segment>
+    </unit>
+    <unit id="key.nested">
+      <segment>
+        <source>XLIFF Data Manager</source>
+        <target>XLIFF Daten Manager</target>
+        <note>Nested note</note>
+      </segment>
+    </unit>
+  </file>
+  <file id="namespace2">
+    <unit id="k">
+      <segment>
+        <source>v</source>
+        <target>v2</target>
+        <note>n</note>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/test/fixtures/example_note12.xliff
+++ b/test/fixtures/example_note12.xliff
@@ -1,0 +1,30 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" srcLang="en-US" trgLang="de-CH">
+  <file original="namespace1">
+    <body>
+      <trans-unit id="key1">
+        <source xml:lang="en-US">Hello</source>
+        <target xml:lang="de-CH">Hallo</target>
+        <note>Hello note</note>
+      </trans-unit>
+      <trans-unit id="key2">
+        <source xml:lang="en-US">An application to manipulate and process XLIFF documents</source>
+        <target xml:lang="de-CH">Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
+        <note>Description note</note>
+      </trans-unit>
+      <trans-unit id="key.nested">
+        <source xml:lang="en-US">XLIFF Data Manager</source>
+        <target xml:lang="de-CH">XLIFF Daten Manager</target>
+        <note>Nested note</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="namespace2">
+    <body>
+      <trans-unit id="k">
+        <source>v</source>
+        <target>v2</target>
+        <note>n</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -15,5 +15,10 @@ module.exports = {
     xliff12: fs.readFileSync(path.join(__dirname, 'example_multi12.xliff')).toString().replace(/\n$/, ''),
     js_source: require('./example_multi_source.json'),
     js_target: require('./example_multi_target.json')
+  },
+  example_note: {
+    js: require('./example_note.json'),
+    xliff: fs.readFileSync(path.join(__dirname, 'example_note.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_note12.xliff')).toString().replace(/\n$/, ''),
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -151,3 +151,49 @@ describe('multi', () => {
   });
 
 });
+
+describe('with notes', () => {
+
+  test('xliff2js', (fn) => (done) => {
+    fn(fixtures.example_note.xliff, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_note.js);
+      done();
+    });
+  });
+
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_note.xliff12, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_note.js);
+      done();
+    });
+  });
+
+  test('js2xliff', (fn) => (done) => {
+    fn(fixtures.example_note.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_note.xliff);
+      done();
+    });
+  });
+
+  test('targetOfjs', (fn) => (done) => {
+    fn(fixtures.example_note.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res.namespace1['key.nested']).to.eql(fixtures.example_note.js.resources.namespace1['key.nested'].target);
+      expect(res.namespace2['k']).to.eql(fixtures.example_note.js.resources.namespace2['k'].target);
+      done();
+    });
+  });
+
+  test('sourceOfjs', (fn) => (done) => {
+    fn(fixtures.example_note.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res.namespace1['key.nested']).to.eql(fixtures.example_note.js.resources.namespace1['key.nested'].source);
+      expect(res.namespace2['k']).to.eql(fixtures.example_note.js.resources.namespace2['k'].source);
+      done();
+    });
+  });
+
+});

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -32,7 +32,8 @@ function xliff12ToJs(str, cb) {
         const key = entry.$.id;
         result.resources[namespace][key] = {
           source: '',
-          target: ''
+          target: '',
+          note: ''
         };
 
         if (entry.source) {
@@ -41,6 +42,9 @@ function xliff12ToJs(str, cb) {
 
         if (entry.target) {
           result.resources[namespace][key].target = extractValue(entry.target[0]);
+        }
+        if (entry.note) {
+          result.resources[namespace][key].note = extractValue(entry.note[0]);
         }
       });
     });

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -32,8 +32,7 @@ function xliff12ToJs(str, cb) {
         const key = entry.$.id;
         result.resources[namespace][key] = {
           source: '',
-          target: '',
-          note: ''
+          target: ''
         };
 
         if (entry.source) {

--- a/xliff2js.js
+++ b/xliff2js.js
@@ -28,7 +28,8 @@ function xliffToJs(str, cb) {
         const key = entry.$.id;
         result.resources[namespace][key] = {
           source: '',
-          target: ''
+          target: '',
+          note: ''
         };
         entry.segment.forEach((seg) => {
           if (seg.source) {
@@ -38,6 +39,10 @@ function xliffToJs(str, cb) {
           if (seg.target) {
             const trgValue = seg.target[0];
             result.resources[namespace][key].target = trgValue;
+          }
+          if (seg.note) {
+            const noteValue = seg.note[0];
+            result.resources[namespace][key].note = noteValue;
           }
         });
       });

--- a/xliff2js.js
+++ b/xliff2js.js
@@ -28,8 +28,7 @@ function xliffToJs(str, cb) {
         const key = entry.$.id;
         result.resources[namespace][key] = {
           source: '',
-          target: '',
-          note: ''
+          target: ''
         };
         entry.segment.forEach((seg) => {
           if (seg.source) {


### PR DESCRIPTION
Our corporate use case requires <note> elements inside <trans-unit> tags

This pull request allows for using <note> elements inside <trans-unit> when converting to and from xliff