### PR TITLE
Use <file source-language> instead of <xliff srcLang>

### DIFF
--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -20,9 +20,7 @@ function jsToXliff12(obj, opt, cb) {
       'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
       'xsi:schemaLocation': 'urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd',
       xmlns: 'urn:oasis:names:tc:xliff:document:1.2',
-      version: '1.2',
-      srcLang: obj.sourceLanguage,
-      trgLang: obj.targetLanguage
+      version: '1.2'
     },
     file: []
   };

--- a/test/fixtures/example_multi12.xliff
+++ b/test/fixtures/example_multi12.xliff
@@ -1,5 +1,5 @@
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" srcLang="en-US" trgLang="de-CH">
-  <file original="namespace1">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
     <body>
       <trans-unit id="key1">
         <source>Hello</source>
@@ -15,7 +15,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="namespace2">
+  <file original="namespace2" datatype="plaintext" source-language="en-US" targe-language="de-CH">
     <body>
       <trans-unit id="k">
         <source>v</source>

--- a/test/fixtures/example_note12.xliff
+++ b/test/fixtures/example_note12.xliff
@@ -1,5 +1,5 @@
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" srcLang="en-US" trgLang="de-CH">
-  <file original="namespace1">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
     <body>
       <trans-unit id="key1">
         <source xml:lang="en-US">Hello</source>

--- a/test/fixtures/example_source_attr12.xliff
+++ b/test/fixtures/example_source_attr12.xliff
@@ -2,16 +2,16 @@
   <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
     <body>
       <trans-unit id="key1">
-        <source>Hello</source>
-        <target>Hallo</target>
+        <source xml:lang="en-US">Hello</source>
+        <target xml:lang="de-CH">Hallo</target>
       </trans-unit>
       <trans-unit id="key2">
-        <source>An application to manipulate and process XLIFF documents</source>
-        <target>Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
+        <source xml:lang="en-US">An application to manipulate and process XLIFF documents</source>
+        <target xml:lang="de-CH">Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
       </trans-unit>
       <trans-unit id="key.nested">
-        <source>XLIFF Data Manager</source>
-        <target>XLIFF Daten Manager</target>
+        <source xml:lang="en-US">XLIFF Data Manager</source>
+        <target xml:lang="de-CH">XLIFF Daten Manager</target>
       </trans-unit>
     </body>
   </file>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,6 +9,10 @@ module.exports = {
     js_source: require('./example_source.json'),
     js_target: require('./example_target.json')
   },
+  example_source_attr: {
+    // The JS should be the same as example.js
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_source_attr12.xliff')).toString().replace(/\n$/, ''),
+  },
   example_multi: {
     js: require('./example_multi.json'),
     xliff: fs.readFileSync(path.join(__dirname, 'example_multi.xliff')).toString().replace(/\n$/, ''),

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,14 @@ describe('single', () => {
     });
   });
 
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example.xliff12);
+      done();
+    });
+  });
+
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example.js, (err, res) => {
       expect(err).not.to.be.ok();
@@ -76,6 +84,18 @@ describe('single', () => {
          done();
        }
     );
+  });
+
+});
+
+describe('xliff 1.2 source/target attributes', () => {
+
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_source_attr.xliff12, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example.js);
+      done();
+    });
   });
 
 });

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -17,8 +17,8 @@ function xliff12ToJs(str, cb) {
   parser.parseString(str, (err, data) => {
     if (err) return cb(err);
 
-    const srcLang = data.xliff.$.srcLang;
-    const trgLang = data.xliff.$.trgLang;
+    const srcLang = data.xliff.file[0].$['source-language'];
+    const trgLang = data.xliff.file[0].$['target-language'];
 
     result.sourceLanguage = srcLang;
     result.targetLanguage = trgLang;


### PR DESCRIPTION
Plus a couple of other spec-related updates

See http://docs.oasis-open.org/xliff/xliff-core/xliff-core.html#Specs_Elem_TopHeader

- Add basic test for jsToXliff12
- Remove `srcLang` and `trgLang` attributes from `<xliff>` -- they're in xliff 2.0 but not 1.2 (#7)
  - Instead, read `sourceLanguage` and `targetLanguage` from the first `<file>` element when doing xliff to JS
- Add required `datatype` attribute to test xliff files
- Remove `xml:lang` attributes from example12.xliff, and make a separate xliff file and test for reading xliff with attributes in source/target elements (see #4)