### PR TITLE
 feature(Add datatype support)

### DIFF
--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -29,7 +29,7 @@ function jsToXliff12(obj, opt, cb) {
     const f = {
       $: {
         original: nsName,
-        datatype: 'plaintext',
+        datatype: obj.datatype || 'plaintext',
         'source-language': obj.sourceLanguage,
         'target-language': obj.targetLanguage
       },
@@ -42,13 +42,17 @@ function jsToXliff12(obj, opt, cb) {
     Object.keys(obj.resources[nsName]).forEach((k) => {
       const u = {
         $: {
-          id: k
+          id: k,
+          datatype: ''
         },
         source: obj.resources[nsName][k].source,
         target: obj.resources[nsName][k].target
       };
       if ('note' in obj.resources[nsName][k]) {
         u.note = obj.resources[nsName][k].note;
+      }
+      if ('datatype' in obj.resources[nsName][k]) {
+        u.$.datatype = obj.resources[nsName][k].datatype;
       }
       f.body['trans-unit'].push(u);
     });

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -17,9 +17,11 @@ function xliff12ToJs(str, cb) {
   parser.parseString(str, (err, data) => {
     if (err) return cb(err);
 
+    const datatype = data.xliff.file[0].$['datatype'];
     const srcLang = data.xliff.file[0].$['source-language'];
     const trgLang = data.xliff.file[0].$['target-language'];
 
+    result.datatype = datatype;
     result.sourceLanguage = srcLang;
     result.targetLanguage = trgLang;
 
@@ -35,10 +37,12 @@ function xliff12ToJs(str, cb) {
           target: ''
         };
 
+        if (entry.$.datatype) {
+          result.resources[namespace][key].datatype = extractValue(entry.$.datatype);
+        }
         if (entry.source) {
           result.resources[namespace][key].source = extractValue(entry.source[0]);
         }
-
         if (entry.target) {
           result.resources[namespace][key].target = extractValue(entry.target[0]);
         }


### PR DESCRIPTION
 Support is given to keep the datatype in both json and xliff in version 1.2
The specification says 
" Required attributes:
original, source-language, datatype.
http://docs.oasis-open.org/xliff/xliff-core/xliff-core.html#file

And http://docs.oasis-open.org/xliff/xliff-core/xliff-core.html#trans-unit