### PR TITLE
Change xml parser to `xml-js`

### DIFF
--- a/js2xliff.js
+++ b/js2xliff.js
@@ -1,5 +1,6 @@
 const convert = require('xml-js');
-const {makeElement, makeText} = require('./util/makeNodes');
+const makeElement = require('./util/makeNodes').makeElement;
+const makeText = require('./util/makeNodes').makeText;
 
 function js2xliff(obj, opt, cb) {
 

--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -1,4 +1,5 @@
 const convert = require('xml-js');
+const {makeElement, makeText} = require('./util/makeNodes');
 
 function jsToXliff12(obj, opt, cb) {
 
@@ -11,79 +12,31 @@ function jsToXliff12(obj, opt, cb) {
     spaces: opt.indent || '  '
   };
 
-  const root = {
-    type: 'element',
-    name: 'xliff',
-    attributes: {
-      'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-      'xsi:schemaLocation': 'urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd',
-      xmlns: 'urn:oasis:names:tc:xliff:document:1.2',
-      version: '1.2'
-    },
-    elements: []
+  const rootAttributes = {
+    'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+    'xsi:schemaLocation': 'urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd',
+    xmlns: 'urn:oasis:names:tc:xliff:document:1.2',
+    version: '1.2'
   };
+  const root = makeElement('xliff', rootAttributes, true);
 
   Object.keys(obj.resources).forEach((nsName) => {
-    const b = {
-      type: 'element',
-      name: 'body',
-      elements: []
+    const b = makeElement('body', null, true);
+    const fileAttributes = {
+      original: nsName,
+      datatype: 'plaintext',
+      'source-language': obj.sourceLanguage,
+      'target-language': obj.targetLanguage
     };
-
-    const f = {
-      type: 'element',
-      name: 'file',
-      attributes: {
-        original: nsName,
-        datatype: 'plaintext',
-        'source-language': obj.sourceLanguage,
-        'target-language': obj.targetLanguage
-      },
-      elements: [b]
-    };
+    const f = makeElement('file', fileAttributes, [b]);
     root.elements.push(f);
 
     Object.keys(obj.resources[nsName]).forEach((k) => {
-      const u = {
-        type: 'element',
-        name: 'trans-unit',
-        attributes: {
-          id: k
-        },
-        elements: [
-          {
-            type: 'element',
-            name: 'source',
-            elements: [
-              {
-                type: 'text',
-                text: obj.resources[nsName][k].source
-              }
-            ]
-          },
-          {
-            type: 'element',
-            name: 'target',
-            elements: [
-              {
-                type: 'text',
-                text: obj.resources[nsName][k].target
-              }
-            ]
-          }
-        ]
-      };
+      const u = makeElement('trans-unit', {id: k}, true);
+      u.elements.push(makeElement('source', null, [makeText(obj.resources[nsName][k].source)]));
+      u.elements.push(makeElement('target', null, [makeText(obj.resources[nsName][k].target)]));
       if ('note' in obj.resources[nsName][k]) {
-        u.elements.push({
-          type: 'element',
-          name: 'note',
-          elements: [
-            {
-              type: 'text',
-              text: obj.resources[nsName][k].note
-            }
-          ]
-        });
+        u.elements.push(makeElement('note', null, [makeText(obj.resources[nsName][k].note)]));
       }
       b.elements.push(u);
     });

--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -1,5 +1,6 @@
 const convert = require('xml-js');
-const {makeElement, makeText} = require('./util/makeNodes');
+const makeElement = require('./util/makeNodes').makeElement;
+const makeText = require('./util/makeNodes').makeText;
 
 function jsToXliff12(obj, opt, cb) {
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "xml-js": "^1.2.2",
-    "xml2js": "0.4.19"
+    "xml-js": "^1.2.2"
   },
   "devDependencies": {
     "eslint": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "xml-js": "^1.2.2",
     "xml2js": "0.4.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "xml-js": "^1.2.2"
+    "xml-js": "1.2.2"
   },
   "devDependencies": {
     "eslint": "^4.4.1",

--- a/util/makeNodes.js
+++ b/util/makeNodes.js
@@ -1,0 +1,24 @@
+function makeElement(name, attributes, elements) {
+  const el = {
+    type: 'element',
+    name: name
+  };
+  if (attributes !== null && attributes !== undefined) {
+    el.attributes = attributes;
+  }
+  if (Array.isArray(elements)) {
+    el.elements = elements;
+  } else if (elements === true) {
+    el.elements = [];
+  }
+  return el;
+}
+exports.makeElement = makeElement;
+
+function makeText(text) {
+  return {
+    type: 'text',
+    text
+  };
+}
+exports.makeText = makeText;

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -11,7 +11,7 @@ function xliff12ToJs(str, cb) {
     return valueElement.type !== 'text' ? extractValue(valueElement.elements[0]) : valueElement.text;
   };
 
-  let xmlObj;
+  var xmlObj;
   try {
     xmlObj = convert.xml2js(str, {});
   } catch (err) {

--- a/xliff2js.js
+++ b/xliff2js.js
@@ -11,7 +11,7 @@ function xliffToJs(str, cb) {
     return valueElement.type !== 'text' ? extractValue(valueElement.elements[0]) : valueElement.text;
   };
 
-  let xmlObj;
+  var xmlObj;
   try {
     xmlObj = convert.xml2js(str, {});
   } catch (err) {


### PR DESCRIPTION
Just to get this out of the way at the start: this probably seems like a drastic change, and I will freely admit that it does to me.

I'm working on a separate pull request to add support for `<ph>` tags in XLIFF 1.2. (This is very similar to #6 and could easily be extended to support other tags such as the ones specified there.) However, one issue I have run into is that the XML parsing library that's currently used in this project ([xml2js](https://www.npmjs.com/package/xml2js)) doesn't support mixed text content and tags properly. Specifically it doesn't preserve the order of the tag and text children -- it just groups all text together and all tags together.

This means that if an XLIFF file has a `source` value like this:
```
Hello there <ph>%(name)</ph>, how are you today?
```
using xml2js we can determine that there is a `<ph>` child element, but not where within the string it belongs.

I found another XML parsing library, [xml-js](https://www.npmjs.com/package/xml-js), that _does_ properly handle child element order. (The library's README includes [a brief explanation of the problem](https://www.npmjs.com/package/xml-js#features).)