### PR TITLE
WIP: Proposal and POC for adding support for Inline elements

### DIFF
--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -1,6 +1,7 @@
 const convert = require('xml-js');
 const makeElement = require('./util/makeNodes').makeElement;
 const makeText = require('./util/makeNodes').makeText;
+const makeValue = require('./util/makeNodes').makeValue;
 
 function jsToXliff12(obj, opt, cb) {
 
@@ -34,8 +35,8 @@ function jsToXliff12(obj, opt, cb) {
 
     Object.keys(obj.resources[nsName]).forEach((k) => {
       const u = makeElement('trans-unit', {id: k}, true);
-      u.elements.push(makeElement('source', null, [makeText(obj.resources[nsName][k].source)]));
-      u.elements.push(makeElement('target', null, [makeText(obj.resources[nsName][k].target)]));
+      u.elements.push(makeElement('source', null, makeValue(obj.resources[nsName][k].source)));
+      u.elements.push(makeElement('target', null, makeValue(obj.resources[nsName][k].target)));
       if ('note' in obj.resources[nsName][k]) {
         u.elements.push(makeElement('note', null, [makeText(obj.resources[nsName][k].note)]));
       }

--- a/multi-child-strawman.md
+++ b/multi-child-strawman.md
@@ -218,6 +218,7 @@ Because of the differences between the two versions' representations, I see a co
 This option is to support a subset of the elements within the data model. Only that subset of elements will be able to be created (JS to XLIFF). When going from XLIFF to JS, elements that aren't defined in the data model will be converted to the closest type, so their semantics are maintained but it won't be possible to do perfect round-tripping XLIFF -> JS -> XLIFF.
 
 Defined element types:
+
 | Element type | Representation (1.2) | Representation (2.0) |
 | ------------ | -------------------- | -------------------- |
 | Standalone | `<x/>` | `<ph/>` | 
@@ -245,6 +246,7 @@ XLIFF 2.0 -> JS
 This option is to support a larger set of elements in the data model. Only the subset that is supported by the version in question will be used when reading XLIFF to JS. For JS to XLIFF, elements that aren't strictly defined in the XLIFF version will be mapped to corresponding supported elements.
 
 Defined element types:
+
 | Element type | Representation (1.2) | Representation (2.0) |
 | ------------ | -------------------- | -------------------- |
 | Standalone | `<x/>` | `<ph/>` | 

--- a/multi-child-strawman.md
+++ b/multi-child-strawman.md
@@ -1,0 +1,287 @@
+Strawman proposal: 
+
+WIP - DO NOT MERGE
+
+This is a proposal for adding support for "inline" child elements that can occur in `source` and `target` values.
+
+I have already built a proof-of-concept implementation for this that adds support for one type of inline element (XLIFF 1.2 `<ph></ph>` elements). However, because this involves making a (backwards-compatible) change to the library's object model, I wanted to open up a conversation about the object model first before writing a complete implementation.
+
+The added file "multi-child-strawman.md" is the text proposal. I added it as a file so that we can add comments and discussion on a per-line basis. All the other code changes are the work for the proof-of-concept implementation.
+
+# Proposal: Adding support for XLIFF inline elements
+
+This proposal is divided into three sections:
+
+1. Changes to the `resources.namespace.key.{source,target}` properties
+2. General structure for representing XLIFF inline elements
+3. Specifics on which elements are supported and how they are mapped between JS and XLIFF (and vice-versa)
+
+
+## Proposal: `source`/`target` value type changes
+### Background
+
+Currently this library's object model for XLIFF documents defines `source` and `target` values as strings:
+
+```
+{
+  "resources": {
+    "namespace1": {
+      "key1": {
+        "source": "Hello",
+        "target": "Hallo"
+      },
+    }
+  },
+  "sourceLanguage": "en-US",
+  "targetLanguage": "de-CH"
+}
+```
+
+In addition to text, the XLIFF specifications define multiple child tags that can be included in `<source>`/`<target>` tags:
+
+- [XLIFF 1.2 spec](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#Specs_Elem_Inline)
+- [XLIFF 2.0 spec](http://docs.oasis-open.org/xliff/xliff-core/v2.0/xliff-core-v2.0.html#inlineCodes)
+
+In general these "inline" tags exist to specify special elements within translation strings. For example, in XLIFF 1.2 the `<ph>..</ph>` element is used to define a "placeholder" such as for a variable value that is substituted at runtime, e.g.:
+
+- String: "Hello there, {fullName}"
+- XLIFF 1.2: `<source>Hello there, <ph>{fullName}</ph></source>`
+
+### Proposed implementation
+I propose that the `source` and `target` properties be changed from only allowing string values to allowing either string _or_ array values:
+```
+// Simple value:
+"source": "Hello there"
+// Value with multiple child elements:
+"source": ["Hello ", "there"]
+```
+(Note that in the example above there's no benefit from splitting the string into two strings wrapped in an array -- it is just shown to avoid making the example overly-complex.)
+
+When the `source` and `target` values are Array instances, they will contain either strings or objects representing XLIFF inline elements. The structure for those objects is described in the next section. 
+
+
+## Proposal: Object structure for non-text elements
+### Background
+XLIFF supports several types of inline elements in `<source>`/`<target>` values (see section 3 of the proposal for an enumeration of them). Each of those element types, in turn, accepts multiple attributes (including attributes not defined in the XLIFF spec). Some of them also accept child text and/or other elements as well.
+
+For example, XLIFF 1.2 defines these inline elements (among others):
+- `<g></g>`:
+  - Required attributes: `id`
+  - Optional attributes: `ctype`, `clone`, `xid`, `equiv-text`, non-XLIFF attributes
+  - Contents: Text; Zero, one or more other inline elements
+- `<x/>`:
+  - Required attributes: `id`
+  - Optional attributes: `ctype`, `clone`, `xid`, `equiv-text`, non-XLIFF attributes
+  - Contents: Empty
+- `<bx/>`:
+  - Required attributes: `id`
+  - Optional attributes: `rid`, `ctype`, `clone`, `xid`, `equiv-text`, non-XLIFF attributes
+  - Contents: Empty
+- `<ex/>`:
+  - Required attributes: `id`
+  - Optional attributes: `rid`, `xid`, `equiv-text`, non-XLIFF attributes
+  - Contents: Empty
+- `<ph></ph>`:
+  - Required attributes: `id`
+  - Optional attributes: `ctype`, `crc`, `assoc`, `xid`, `equiv-text`, and non-XLIFF attributes
+  - Contents: Code data; Zero, one or more `<sub>` elements
+
+While there are some consistencies, there is also some variation among the elements. Consequently, the object structure for inline elements needs to be flexible enough to support various attributes and child elements.
+
+### Proposed implementation
+Rather than establishing a strict definition for the object structure of each element type, I propose using a flexible object structure that supports any element type. The benefit of this approach is the flexibility and (hopefully) being able to handle unexpected or non-conforming data. The downside is that there is no guarantee that a given object structure actually represents a valid XLIFF structure.
+
+Here are two options for object structure. I don't have a strong preference for either one.
+
+Option 1 feels more "modern" (I guess it is inspired by the style of [React Immutability Helpers' `update` command object](https://reactjs.org/docs/update.html#update)). This is the approach I've used in my proof-of-concept implementation.
+
+However, Option 2 feels simpler (though more "rigidly structured") and it will likely be easier to work with in code.
+
+#### Option 1
+The proposed structure is:
+```
+{
+  [<Element Type>]: {
+    "id": "<Value>",
+    "contents": "<Element Contents>",
+    "<Other Property 1>": "<Other Property 1 Value>",
+    ...
+    "<Other Property N>": "<Other Property N Value>"
+  }
+}
+```
+The parts are:
+- `<Element Type>`: A string (used as a property name) indicating the element type. The set of possible types will be defined as constants
+- `id` property: The value of the XLIFF element's `id` attribute
+- `contents` property: The contents of the XLIFF element, if supported. This value can be a string or array and is treated like the `source`/`target` values.
+- All other properties: Map directly to attributes of the XLIFF element tag
+
+Here's a real-world example of the proposed structure:
+```
+{
+  "ph": {
+    "id": "dataType",
+    "contents": "{dataType}",
+    "ctype": "x-python-brace-param"
+  }
+}
+```
+This maps to the following XLIFF inline element structure:
+```
+<ph id="dataType" ctype="x-python-brace-param">{dataType}</ph>
+```
+
+#### Option 2
+The proposed structure is:
+```
+{
+  "type": "<Element Type>",
+  "id": "<Value>",
+  "contents": "<Element Contents>",
+  "attributes": [
+    { "<Attribute 1>": "<Attribute 1 Value>" },
+    ...,
+    { "<Attribute N>": "<Attribute N Value>" }
+  ]
+}
+```
+The parts are:
+- `<Element Type>`: A string (used as a property name) indicating the element type. The set of possible types will be defined as constants
+- `id` property: The value of the XLIFF element's `id` attribute
+- `contents` property: The contents of the XLIFF element, if supported. This value can be a string or array and is treated like the `source`/`target` values.
+- `attributes` property: Array of objects, each of which contains one key (the attribute name) and one value (a string, the attribute value). These correspond to attributes of the XLIFF element tag (other than `id`).
+
+Here's a real-world example of the proposed structure:
+```
+{
+  "type": "ph",
+  "id": "dataType",
+  "contents": "{dataType}",
+  "attributes": [{ "ctype": "x-python-brace-param" }]
+}
+```
+This maps to the following XLIFF inline element structure:
+```
+<ph id="dataType" ctype="x-python-brace-param">{dataType}</ph>
+```
+
+The next section describes the set of inline elements that will be available.
+
+## Proposal: Supported element types
+### Background
+
+Unfortunately XLIFF 1.2 and XLIFF 2.0 differ in which specific tags are used to represent different types of inline elements:
+
+#### XLIFF 2.0 inline elements
+
+- Standalone code (`<ph/>`) - Corresponds to a single position in the content (e.g. the `<br/>` tag in HTML)
+- Well-formed spanning code (`<pc></pc>`) - A code that wraps a section of content using a start and end marker (e.g. the `<b></b>` tag in HTML), that is properly nested (i.e. all spans are completely contained by other spans that wrap them)
+- Start marker of spanning code (`<sc/>`) - Start marker of a span that isn't properly nested or crosses segment boundaries ("orphan")
+- End marker of spanning code (`<ec/>`) - End marker of a span that isn't properly nested or crosses segment boundaries
+
+#### XLIFF 1.2 inline elements
+
+- Generic group placeholder (`<g></g>`) - Generic, well-formed spanning code.
+- Generic standalone placeholder (`<x/>`) - Generic isolated item in the content
+- Begin paired placeholder (`<bx/>`) - Start marker of a span that isn't properly nested
+- End paired placeholder (`<ex/>`) - End marker of a span that isn't properly nested
+- Placeholder (`<ph></ph>`) - Native well-formed spanning code
+- Begin paired tag (`<bpt></bpt>`) - Start marker of a paired sequence of native codes
+- End paired tag (`<ept></ept>`) - End marker of a paired sequence of native codes
+- Isolated tag (`<it></it>`) - Start or end marker of a paired sequence of native codes where the companion marker isn't in the translation unit
+- Sub-flow (`<sub></sub>`) - Sub-flow text inside a native code sequence (e.g. the `title` element of an HTML `<a>` tag) 
+
+
+Although the two versions define different elements, the underlying semantics of many of the elements are the same and they can be mapped to each other:
+
+| Use Case | Representation (1.2) | Representation (2.0) |
+| -------- | -------------------- | -------------------- |
+| **Generic** |
+| Standalone code | `<x/>` | `<ph/>` | 
+| Well-formed spanning code | `<g></g>` | `<pc></pc>` |
+| Start marker of spanning code | `<bx/>` | `<sc/>` |
+| End marker of spanning code | `<ex/>` | `<ec/>` |
+| Orphan start marker of spanning code | n/a | `<sc isolated="yes"/>` |
+| Orphan end marker of spanning code | n/a | `<ec isolated="yes"/>` |
+| **Native code** (same as generic for 2.0) | |  |
+| Well-formed spanning code | `<ph></ph>` | `<pc></pc>` |
+| Start marker of spanning code | `<bpt></bpt>` | `<sc/>` |
+| End marker of spanning code | `<ept></ept>` | `<ec/>` |
+| Orphan start marker of spanning code | `<it></it>` | `<sc isolated="yes"/>` |
+| Orphan end marker of spanning code | `<it></it>` | `<ec isolated="yes"/>` |
+| Sub-flow text | `<sub></sub>` | (separate `<unit></unit>`) |
+
+### Proposed implementation
+Because of the differences between the two versions' representations, I see a couple of options for how to structure the data model to represent them:
+
+#### Option 1: Common subset
+This option is to support a subset of the elements within the data model. Only that subset of elements will be able to be created (JS to XLIFF). When going from XLIFF to JS, elements that aren't defined in the data model will be converted to the closest type, so their semantics are maintained but it won't be possible to do perfect round-tripping XLIFF -> JS -> XLIFF.
+
+Defined element types:
+| Element type | Representation (1.2) | Representation (2.0) |
+| ------------ | -------------------- | -------------------- |
+| Standalone | `<x/>` | `<ph/>` | 
+| Span | `<g></g>` | `<pc></pc>` |
+| SpanStart | `<bx/>` | `<sc/>` |
+| SpanEnd | `<ex/>` | `<ec/>` |
+
+Orphan markers will not be supported at this time.
+
+Mapping rules:
+JS -> XLIFF 1.2
+  Elements are written as generic elements -- the library will not generate "native code" elements
+
+JS -> XLIFF 2.0
+  Elements are written as their corresponding types
+
+XLIFF 1.2 -> JS
+  Elements are read and native elements are converted to their generic counterparts
+
+XLIFF 2.0 -> JS
+  Elements are read as their corresponding types
+
+
+#### Option 2: Superset  
+This option is to support a larger set of elements in the data model. Only the subset that is supported by the version in question will be used when reading XLIFF to JS. For JS to XLIFF, elements that aren't strictly defined in the XLIFF version will be mapped to corresponding supported elements.
+
+Defined element types:
+| Element type | Representation (1.2) | Representation (2.0) |
+| ------------ | -------------------- | -------------------- |
+| Standalone | `<x/>` | `<ph/>` | 
+| GenericSpan | `<g></g>` | `<pc></pc>` |
+| GenericSpanStart | `<bx/>` | `<sc/>` |
+| GenericSpanEnd | `<ex/>` | `<ec/>` |
+| Span | `<ph></ph>` | `<pc></pc>` |
+| SpanStart | `<bpt></bpt>` | `<sc/>` |
+| SpanEnd | `<ept></ept>` | `<ec/>` |
+
+Orphan markers will not be supported at this time.
+
+Mapping rules:
+JS -> XLIFF 1.2
+  Elements are written as their corresponding types
+
+JS -> XLIFF 2.0
+  Elements are written as their corresponding types. Native/generic types are mapped to the same XLIFF element type
+
+XLIFF 1.2 -> JS
+  Elements are read as their corresponding types
+
+XLIFF 2.0 -> JS
+  Elements are read as their corresponding (non-generic) types
+
+#### Option 3: Two data models
+This option is to fork the data models and have one set of elements for XLIFF 1.2 and another set for XLIFF 2.0. With this option, the JS data model for one XLIFF version would not work for the other XLIFF version.
+
+
+## Proposal: Helper functions
+Because the data model proposed here is notably more complex than the previous one, it will simplify the implementation to have helper functions for creating the different elements that can be part of a `source`/`target` value.
+ 
+In addition, those functions will likely be helpful to users of the library to create `source` and `target` values. Consequently, it seems like a good idea for those functions to be made available as part of the defined API of the library.
+ 
+ 
+ ## Ideas for future work
+ Future work could include:
+ - Creating an XLIFF builder class structure (or set of functions) that combines helper functions into a single bundle with state that includes a `toXLIFF()` method for creating the XML string.
+ - Creating source/target value parsers that, given an original string, construct the corresponding data structure. (For example, call the parser function with `"Hello there {fullName}"` and it returns the corresponding data model.) This would probably require ongoing work to support additional formats of strings, so it is able to recognize HTML or similar tags, etc.
+

--- a/multi-child-strawman.md
+++ b/multi-child-strawman.md
@@ -138,11 +138,11 @@ The proposed structure is:
   "type": "<Element Type>",
   "id": "<Value>",
   "contents": "<Element Contents>",
-  "attributes": [
-    { "<Attribute 1>": "<Attribute 1 Value>" },
+  "attributes": {
+    "<Attribute 1>": "<Attribute 1 Value>",
     ...,
-    { "<Attribute N>": "<Attribute N Value>" }
-  ]
+    "<Attribute N>": "<Attribute N Value>"
+  }
 }
 ```
 The parts are:
@@ -157,7 +157,7 @@ Here's a real-world example of the proposed structure:
   "type": "ph",
   "id": "dataType",
   "contents": "{dataType}",
-  "attributes": [{ "ctype": "x-python-brace-param" }]
+  "attributes": { "ctype": "x-python-brace-param" }
 }
 ```
 This maps to the following XLIFF inline element structure:

--- a/test/fixtures/example_i18next_placeholder.json
+++ b/test/fixtures/example_i18next_placeholder.json
@@ -1,0 +1,28 @@
+{
+  "resources": {
+    "namespace1": {
+      "basic": {
+        "source": [
+          { "ph": { "id": "name", "ctype": "x-i18next-param", "content": "{{name}}" } },
+          " is ",
+          { "ph": { "id": "how", "ctype": "x-i18next-param", "content": "{{how}}" } }
+        ],
+        "target": ""
+      },
+      "data-models": {
+        "source": ["i am ", { "ph": { "id": "author.name", "ctype": "x-i18next-param", "content": "{{author.name}}" } }],
+        "target": ""
+      },
+      "keyEscaped": {
+        "source": ["no danger ", { "ph": { "id": "myVar", "ctype": "x-i18next-param", "content": "{{myVar}}" } }],
+        "target": ""
+      },
+      "keyUnescaped": {
+        "source": ["dangerous ", { "ph": { "id": "myVar", "ctype": "x-i18next-unescaped-param", "content": "{{- myVar}}" } }],
+        "target": ""
+      }
+    }
+  },
+  "sourceLanguage": "en-US",
+  "targetLanguage": "de-CH"
+}

--- a/test/fixtures/example_i18next_placeholder12.xliff
+++ b/test/fixtures/example_i18next_placeholder12.xliff
@@ -1,0 +1,31 @@
+<xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
+    <body>
+      <trans-unit id="basic">
+        <source>
+          <ph id="name" ctype="x-i18next-param">{{name}}</ph> is 
+          <ph id="how" ctype="x-i18next-param">{{how}}</ph>
+        </source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="data-models">
+        <source>i am 
+          <ph id="author.name" ctype="x-i18next-param">{{author.name}}</ph>
+        </source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="keyEscaped">
+        <source>no danger 
+          <ph id="myVar" ctype="x-i18next-param">{{myVar}}</ph>
+        </source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="keyUnescaped">
+        <source>dangerous 
+          <ph id="myVar" ctype="x-i18next-unescaped-param">{{- myVar}}</ph>
+        </source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/example_i18next_unstructured_placeholder.json
+++ b/test/fixtures/example_i18next_unstructured_placeholder.json
@@ -1,0 +1,24 @@
+{
+  "resources": {
+    "namespace1": {
+      "basic": {
+        "source": "{{name}} is {{how}}",
+        "target": ""
+      },
+      "data-models": {
+        "source": "i am {{author.name}}",
+        "target": ""
+      },
+      "keyEscaped": {
+        "source": "no danger {{myVar}}",
+        "target": ""
+      },
+      "keyUnescaped": {
+        "source": "dangerous {{- myVar}}",
+        "target": ""
+      }
+    }
+  },
+  "sourceLanguage": "en-US",
+  "targetLanguage": "de-CH"
+}

--- a/test/fixtures/example_i18next_unstructured_placeholder12.xliff
+++ b/test/fixtures/example_i18next_unstructured_placeholder12.xliff
@@ -1,0 +1,22 @@
+<xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
+    <body>
+      <trans-unit id="basic">
+        <source>{{name}} is {{how}}</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="data-models">
+        <source>i am {{author.name}}</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="keyEscaped">
+        <source>no danger {{myVar}}</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="keyUnescaped">
+        <source>dangerous {{- myVar}}</source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/example_placeholder.json
+++ b/test/fixtures/example_placeholder.json
@@ -1,0 +1,20 @@
+{
+  "resources": {
+    "namespace1": {
+      "key1": {
+        "source": ["Hello ", { "ph": { "id": "name", "ctype": "x-python-brace-param", "content": "{name}" } }],
+        "target": ["Hallo ", { "ph": { "id": "name", "ctype": "x-python-brace-param", "content": "{name}" } }]
+      },
+      "key2": {
+        "source": ["An application to manipulate and process ", { "ph": { "id": "doctype", "ctype": "x-python-brace-param", "content": "{doctype}" } }, " documents"],
+        "target": ["Eine Applikation um ", { "ph": { "id": "doctype", "ctype": "x-python-brace-param", "content": "{doctype}" } }, " Dokumente zu manipulieren und verarbeiten"]
+      },
+      "key.nested": {
+        "source": [{ "ph": { "id": "dataType", "ctype": "x-python-brace-param", "content": "{dataType}" } }, " Data Manager"],
+        "target": [{ "ph": { "id": "dataType", "ctype": "x-python-brace-param", "content": "{dataType}" } }, " Daten Manager"]
+      }
+    }
+  },
+  "sourceLanguage": "en-US",
+  "targetLanguage": "de-CH"
+}

--- a/test/fixtures/example_placeholder.xliff
+++ b/test/fixtures/example_placeholder.xliff
@@ -1,0 +1,34 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="de-CH">
+  <file id="namespace1">
+    <unit id="key1">
+      <segment>
+        <source>Hello 
+          <ph id="name" ctype="x-python-brace-param">{name}</ph>
+        </source>
+        <target>Hallo 
+          <ph id="name" ctype="x-python-brace-param">{name}</ph>
+        </target>
+      </segment>
+    </unit>
+    <unit id="key2">
+      <segment>
+        <source>An application to manipulate and process 
+          <ph id="doctype" ctype="x-python-brace-param">{doctype}</ph> documents
+        </source>
+        <target>Eine Applikation um 
+          <ph id="doctype" ctype="x-python-brace-param">{doctype}</ph> Dokumente zu manipulieren und verarbeiten
+        </target>
+      </segment>
+    </unit>
+    <unit id="key.nested">
+      <segment>
+        <source>
+          <ph id="dataType" ctype="x-python-brace-param">{dataType}</ph> Data Manager
+        </source>
+        <target>
+          <ph id="dataType" ctype="x-python-brace-param">{dataType}</ph> Daten Manager
+        </target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/test/fixtures/example_placeholder12.xliff
+++ b/test/fixtures/example_placeholder12.xliff
@@ -1,0 +1,30 @@
+<xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
+    <body>
+      <trans-unit id="key1">
+        <source>Hello 
+          <ph id="name" ctype="x-python-brace-param">{name}</ph>
+        </source>
+        <target>Hallo 
+          <ph id="name" ctype="x-python-brace-param">{name}</ph>
+        </target>
+      </trans-unit>
+      <trans-unit id="key2">
+        <source>An application to manipulate and process 
+          <ph id="doctype" ctype="x-python-brace-param">{doctype}</ph> documents
+        </source>
+        <target>Eine Applikation um 
+          <ph id="doctype" ctype="x-python-brace-param">{doctype}</ph> Dokumente zu manipulieren und verarbeiten
+        </target>
+      </trans-unit>
+      <trans-unit id="key.nested">
+        <source>
+          <ph id="dataType" ctype="x-python-brace-param">{dataType}</ph> Data Manager
+        </source>
+        <target>
+          <ph id="dataType" ctype="x-python-brace-param">{dataType}</ph> Daten Manager
+        </target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/example_placeholder_source.json
+++ b/test/fixtures/example_placeholder_source.json
@@ -1,0 +1,5 @@
+{
+  "key1": ["Hello ", { "ph": { "id": "name", "ctype": "x-python-brace-param", "content": "{name}" } }],
+  "key2": ["An application to manipulate and process ", { "ph": { "id": "doctype", "ctype": "x-python-brace-param", "content": "{doctype}" } }, " documents"],
+  "key.nested": [{ "ph": { "id": "dataType", "ctype": "x-python-brace-param", "content": "{dataType}" } }, " Data Manager"]
+}

--- a/test/fixtures/example_placeholder_target.json
+++ b/test/fixtures/example_placeholder_target.json
@@ -1,0 +1,5 @@
+{
+  "key1": ["Hallo ", { "ph": { "id": "name", "ctype": "x-python-brace-param", "content": "{name}" } }],
+  "key2": ["Eine Applikation um ", { "ph": { "id": "doctype", "ctype": "x-python-brace-param", "content": "{doctype}" } }, " Dokumente zu manipulieren und verarbeiten"],
+  "key.nested": [{ "ph": { "id": "dataType", "ctype": "x-python-brace-param", "content": "{dataType}" } }, " Daten Manager"]
+}

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -24,5 +24,12 @@ module.exports = {
     js: require('./example_note.json'),
     xliff: fs.readFileSync(path.join(__dirname, 'example_note.xliff')).toString().replace(/\n$/, ''),
     xliff12: fs.readFileSync(path.join(__dirname, 'example_note12.xliff')).toString().replace(/\n$/, ''),
+  },
+  example_placeholder: {
+    js: require('./example_placeholder.json'),
+    //xliff: fs.readFileSync(path.join(__dirname, 'example_placeholder.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_placeholder12.xliff')).toString().replace(/\n$/, ''),
+    js_source: require('./example_placeholder_source.json'),
+    js_target: require('./example_placeholder_target.json')
   }
 };

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -31,5 +31,13 @@ module.exports = {
     xliff12: fs.readFileSync(path.join(__dirname, 'example_placeholder12.xliff')).toString().replace(/\n$/, ''),
     js_source: require('./example_placeholder_source.json'),
     js_target: require('./example_placeholder_target.json')
+  },
+  example_i18next_placeholder: {
+    js: require('./example_i18next_placeholder.json'),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_i18next_placeholder12.xliff')).toString().replace(/\n$/, ''),
+  },
+  example_i18next_unstructured_placeholder: {
+    js: require('./example_i18next_unstructured_placeholder.json'),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_i18next_unstructured_placeholder12.xliff')).toString().replace(/\n$/, ''),
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -236,3 +236,55 @@ describe('with notes', () => {
   });
 
 });
+
+describe('with placeholders', () => {
+
+  //test('xliff2js', (fn) => (done) => {
+  //  fn(fixtures.example_placeholder.xliff, (err, res) => {
+  //    expect(err).not.to.be.ok();
+  //    expect(res).to.eql(fixtures.example_placeholder.js);
+  //    done();
+  //  });
+  //});
+
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_placeholder.xliff12, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_placeholder.js);
+      done();
+    });
+  });
+
+  //test('js2xliff', (fn) => (done) => {
+  //  fn(fixtures.example_placeholder.js, (err, res) => {
+  //    expect(err).not.to.be.ok();
+  //    expect(res).to.eql(fixtures.example_placeholder.xliff);
+  //    done();
+  //  });
+  //});
+
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example_placeholder.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_placeholder.xliff12);
+      done();
+    });
+  });
+
+  test('targetOfjs', (fn) => (done) => {
+    fn(fixtures.example_placeholder.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res['key.nested']).to.eql(fixtures.example_placeholder.js.resources.namespace1['key.nested'].target);
+      done();
+    });
+  });
+
+  test('sourceOfjs', (fn) => (done) => {
+    fn(fixtures.example_placeholder.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res['key.nested']).to.eql(fixtures.example_placeholder.js.resources.namespace1['key.nested'].source);
+      done();
+    });
+  });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -288,3 +288,43 @@ describe('with placeholders', () => {
   });
 
 });
+
+describe('with i18next placeholders (structured)', () => {
+
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_i18next_placeholder.xliff12, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_i18next_placeholder.js);
+      done();
+    });
+  });
+
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example_i18next_placeholder.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_i18next_placeholder.xliff12);
+      done();
+    });
+  });
+
+});
+
+describe('with i18next placeholders (unstructured)', () => {
+
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_i18next_unstructured_placeholder.xliff12, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_i18next_unstructured_placeholder.js);
+      done();
+    });
+  });
+
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example_i18next_unstructured_placeholder.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_i18next_unstructured_placeholder.xliff12);
+      done();
+    });
+  });
+
+});

--- a/util/extractNodes.js
+++ b/util/extractNodes.js
@@ -1,0 +1,27 @@
+function extractValue(valueElements) {
+  if (Array.isArray(valueElements) && valueElements.length > 1) {
+    return valueElements.map(extractValue);
+  }
+
+  const valueElement = Array.isArray(valueElements) ? valueElements[0] || '' : valueElements;
+
+  // text node
+  if (valueElement.type === 'text') {
+    return valueElement.text.indexOf('\n') === -1 ? valueElement.text : valueElement.text.substr(0, valueElement.text.lastIndexOf('\n'));
+  }
+
+  // nested placeholder tag
+  if (valueElement.type === 'element' && valueElement.name === 'ph') {
+    return {
+      ph: {
+        id: valueElement.attributes.id,
+        ctype: valueElement.attributes.ctype,
+        content: extractValue(valueElement.elements),
+      }
+    };
+  }
+
+  // just ignore anything else
+  return '';
+}
+exports.extractValue = extractValue;

--- a/util/extractNodes.js
+++ b/util/extractNodes.js
@@ -1,4 +1,8 @@
 function extractValue(valueElements) {
+  if (valueElements === undefined || valueElements === null || valueElements === '') {
+    return '';
+  }
+
   if (Array.isArray(valueElements) && valueElements.length > 1) {
     return valueElements.map(extractValue);
   }

--- a/util/makeNodes.js
+++ b/util/makeNodes.js
@@ -22,3 +22,22 @@ function makeText(text) {
   };
 }
 exports.makeText = makeText;
+
+function makeValue(content) {
+  if (!Array.isArray(content)) {
+    return [makeText(content)];
+  }
+
+  return content.map((segment) => {
+    if (typeof segment === 'string' || segment instanceof String) {
+      return makeText(segment);
+    } else if ('ph' in segment) {
+      const phAttrs = ['id', 'ctype'].reduce((result, key) => {
+        if (segment.ph[key] !== undefined) { result[key] = segment.ph[key]; }
+        return result;
+      }, {});
+      return makeElement('ph', phAttrs, [makeText(segment.ph.content)]);
+    }
+  });
+}
+exports.makeValue = makeValue;

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -1,4 +1,5 @@
 const convert = require('xml-js');
+const extractValue = require('./util/extractNodes').extractValue;
 
 function xliff12ToJs(str, cb) {
   if (typeof str !== 'string') {
@@ -6,10 +7,6 @@ function xliff12ToJs(str, cb) {
   }
 
   const result = {};
-
-  const extractValue = (valueElement) => {
-    return valueElement.type !== 'text' ? extractValue(valueElement.elements[0]) : valueElement.text;
-  };
 
   var xmlObj;
   try {
@@ -42,7 +39,7 @@ function xliff12ToJs(str, cb) {
           case 'source':
           case 'target':
           case 'note':
-            unit[element.name] = element.elements ? extractValue(element.elements[0]) : undefined;
+            unit[element.name] = extractValue(element.elements);
             break;
         }
 


### PR DESCRIPTION
WIP - DO NOT MERGE

This is a proposal for adding support for "inline" child elements that can occur in `source` and `target` values. (Related: #6)

I have built a proof-of-concept implementation for this that adds support for one type of inline element (XLIFF 1.2 `<ph></ph>` elements). However, because this involves making a (backwards-compatible) change to the library's object model, I wanted to open up a conversation about the object model changes first before writing a complete implementation.

I also added a file "[multi-child-strawman.md](https://github.com/locize/xliff/pull/13/files#diff-8a34e288b33c3ebfcf2d7a645afec752)" containing the text of the proposal. This file isn't meant to be merged in -- I just added it as a file in the repository so that we can add comments and discussion on a per-line basis. All the other code changes are the work for the proof-of-concept implementation.

Once a decision is reached on the object model changes, I plan to do the full implementation (probably in a separate Pull Request).
