### PR TITLE
Fix bug where content is lost when parsing

### DIFF
--- a/test/xml-js/xmlToObject.test.js
+++ b/test/xml-js/xmlToObject.test.js
@@ -20,6 +20,18 @@ describe('extractValue() converts XML source/target values into xliff.js objects
     expect(extractValue({ type: 'text', text: 'Hello \n' }, ElementTypes12)).to.eql('Hello ');
   });
 
+  it('removes a trailing line break and space from a "formatted" XML text element', () => {
+    expect(extractValue({ type: 'text', text: 'Hello \n   ' }, ElementTypes12)).to.eql('Hello ');
+  });
+
+  it('removes trailing line breaks from a "formatted" XML text element with an embedded line break', () => {
+    expect(extractValue({ type: 'text', text: 'Hello \n There\n   ' }, ElementTypes12)).to.eql('Hello \n There');
+  });
+
+  it('does not throw away content from a "formatted" XML text element with no trailing line break', () => {
+    expect(extractValue({ type: 'text', text: 'Hello \n There' }, ElementTypes12)).to.eql('Hello \n There');
+  });
+
   it('creates objects for all supported inline element types', () => {
     const supportedElementTypes = Object.keys(ElementTypes);
     supportedElementTypes.forEach((expectedType) => {

--- a/xml-js/xmlToObject.js
+++ b/xml-js/xmlToObject.js
@@ -13,7 +13,10 @@ function extractValue(valueElements, elementTypeInfo) {
 
   // text node
   if (valueElement.type === 'text') {
-    return valueElement.text.indexOf('\n') === -1 ? valueElement.text : valueElement.text.substr(0, valueElement.text.lastIndexOf('\n'));
+    if (/\n\s*$/.test(valueElement.text)) {
+      return valueElement.text.substr(0, valueElement.text.lastIndexOf('\n'));
+    }
+    return valueElement.text;
   }
 
   // nested inline element tag


### PR DESCRIPTION
Only trim trailing newline + whitespace when it is at the very end of the text node.
This way if a string contains newlines but the closing tag is on the same line as
the last line of text, the string is still parsed correctly.

This should fix #18 