### PR TITLE
Fix for files with a header tag before the body

### DIFF
--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -30,7 +30,7 @@ function xliff12ToJs(str, cb) {
   result.resources = xliffRoot.elements.reduce((resources, file) => {
     const namespace = file.attributes.original;
 
-    const body = file.elements[0];
+    const body = file.elements.find(e => e.name === 'body');
     const transUnits = body.elements;
 
     // namespace

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -30,7 +30,7 @@ function xliff12ToJs(str, cb) {
   result.resources = xliffRoot.elements.reduce((resources, file) => {
     const namespace = file.attributes.original;
 
-    const body = file.elements.find(e => e.name === 'body');
+    const body = file.elements.find((e) => e.name === 'body');
     const transUnits = body.elements;
 
     // namespace


### PR DESCRIPTION
POEditor tool adds a header element to the XLIFF file:

```xml
    <header>
      <tool tool-id="poeditor.com" tool-name="POEditor"/>
    </header>
```

The simple fix is to find the body element instead of getting the first child.