### PR TITLE
Add additional attributes to js and xliff/xliff12 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
+.idea
 npm-debug.log
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -495,3 +495,37 @@ var inlineElementObj = makeInlineElement(ElementTypes.GenericSpan, 'name', attri
 
 var source = [ 'Hello ', inlineElementObj ];
 ```
+
+### Additional attributes example
+It is possible to pass `additionalAttributes` to your js file. These will be added to the `<trans-unit>` element in xliff:
+
+```js
+const js = {
+  "resources": {
+    "namespace1": {
+      "key1": {
+        "source": "Hello",
+        "target": "Hallo",
+        "additionalAttributes": {
+          "translate": "no",
+          "approved": "yes"
+        }
+      }
+    }
+  }
+}
+```
+
+Of course, this also works the other way around:
+```js
+const xliff = `<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="de-CH">
+  <file id="namespace1">
+    <unit id="key1" translate="no" approved="yes">
+      <segment>
+        <source>Hello</source>
+        <target>Hallo</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>`
+```

--- a/js2xliff.js
+++ b/js2xliff.js
@@ -35,7 +35,8 @@ function js2xliff(obj, opt, cb) {
       if ('note' in obj.resources[nsName][k]) {
         segment.elements.push(makeElement('note', null, [makeText(obj.resources[nsName][k].note)]));
       }
-      const u = makeElement('unit', {id: escape(k)}, [segment]);
+      const additionalAttributes = obj.resources[nsName][k].additionalAttributes != null ? obj.resources[nsName][k].additionalAttributes : {};
+      const u = makeElement('unit', Object.assign({id: escape(k)}, additionalAttributes), [segment]);
       f.elements.push(u);
     });
   });

--- a/jsToXliff12.js
+++ b/jsToXliff12.js
@@ -38,7 +38,8 @@ function jsToXliff12(obj, opt, cb) {
     root.elements.push(f);
 
     Object.keys(obj.resources[nsName]).forEach((k) => {
-      const u = makeElement('trans-unit', {id: escape(k)}, true);
+      const additionalAttributes = obj.resources[nsName][k].additionalAttributes != null ? obj.resources[nsName][k].additionalAttributes : {};
+      const u = makeElement('trans-unit', Object.assign({id: escape(k)}, additionalAttributes), true);
       u.elements.push(makeElement('source', null, makeValue(obj.resources[nsName][k].source, ElementTypes12)));
       if (obj.resources[nsName][k].target != null) {
         u.elements.push(makeElement('target', null, makeValue(obj.resources[nsName][k].target, ElementTypes12)));

--- a/test/fixtures/example_additional_attributes.json
+++ b/test/fixtures/example_additional_attributes.json
@@ -1,0 +1,35 @@
+{
+  "resources": {
+    "namespace1": {
+      "key1": {
+        "source": "Hello",
+        "target": "Hallo",
+        "additionalAttributes": {
+          "translate": "no"
+        }
+      },
+      "key2": {
+        "source": "An application to manipulate and process XLIFF documents",
+        "target": "Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten",
+        "note": "Description note"
+      },
+      "key.nested": {
+        "source": "XLIFF Data Manager",
+        "target": "XLIFF Daten Manager"
+      }
+    },
+    "namespace2": {
+      "k": {
+        "source": "v",
+        "target": "v2",
+        "note": "n",
+        "additionalAttributes": {
+          "translate": "no",
+          "approved": "yes"
+        }
+      }
+    }
+  },
+  "sourceLanguage": "en-US",
+  "targetLanguage": "de-CH"
+}

--- a/test/fixtures/example_additional_attributes.xliff
+++ b/test/fixtures/example_additional_attributes.xliff
@@ -1,0 +1,32 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="de-CH">
+  <file id="namespace1">
+    <unit id="key1" translate="no">
+      <segment>
+        <source>Hello</source>
+        <target>Hallo</target>
+      </segment>
+    </unit>
+    <unit id="key2">
+      <segment>
+        <source>An application to manipulate and process XLIFF documents</source>
+        <target>Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
+        <note>Description note</note>
+      </segment>
+    </unit>
+    <unit id="key.nested">
+      <segment>
+        <source>XLIFF Data Manager</source>
+        <target>XLIFF Daten Manager</target>
+      </segment>
+    </unit>
+  </file>
+  <file id="namespace2">
+    <unit id="k" translate="no" approved="yes">
+      <segment>
+        <source>v</source>
+        <target>v2</target>
+        <note>n</note>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/test/fixtures/example_additional_attributes12.xliff
+++ b/test/fixtures/example_additional_attributes12.xliff
@@ -1,0 +1,28 @@
+<xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="namespace1" datatype="plaintext" source-language="en-US" target-language="de-CH">
+    <body>
+      <trans-unit id="key1" translate="no">
+        <source>Hello</source>
+        <target>Hallo</target>
+      </trans-unit>
+      <trans-unit id="key2">
+        <source>An application to manipulate and process XLIFF documents</source>
+        <target>Eine Applikation um XLIFF Dokumente zu manipulieren und verarbeiten</target>
+        <note>Description note</note>
+      </trans-unit>
+      <trans-unit id="key.nested">
+        <source>XLIFF Data Manager</source>
+        <target>XLIFF Daten Manager</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="namespace2" datatype="plaintext" source-language="en-US" target-language="de-CH">
+    <body>
+      <trans-unit id="k" translate="no" approved="yes">
+        <source>v</source>
+        <target>v2</target>
+        <note>n</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -24,5 +24,10 @@ module.exports = {
     js: require('./example_note.json'),
     xliff: fs.readFileSync(path.join(__dirname, 'example_note.xliff')).toString().replace(/\n$/, ''),
     xliff12: fs.readFileSync(path.join(__dirname, 'example_note12.xliff')).toString().replace(/\n$/, ''),
+  },
+  example_additional_attributes: {
+    js: require('./example_additional_attributes'),
+    xliff: fs.readFileSync(path.join(__dirname, 'example_additional_attributes.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_additional_attributes12.xliff')).toString().replace(/\n$/, '')
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,40 @@ describe('xliff 1.2 source/target attributes', () => {
 
 });
 
+describe('xliff additional attributes', () => {
+  test('xliff2js', (fn) => (done) => {
+    fn(fixtures.example_additional_attributes.xliff, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_additional_attributes.js);
+      done();
+    });
+  });
+  test('js2xliff', (fn) => (done) => {
+    fn(fixtures.example_additional_attributes.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_additional_attributes.xliff);
+      done();
+    });
+  });
+});
+
+describe('xliff 1.2 additional attributes', () => {
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_additional_attributes.xliff12, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_additional_attributes.js);
+      done();
+    });
+  });
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example_additional_attributes.js, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_additional_attributes.xliff12);
+      done();
+    });
+  });
+});
+
 describe('multi', () => {
 
   test('xliff2js', (fn) => (done) => {

--- a/test/test.js
+++ b/test/test.js
@@ -117,40 +117,6 @@ describe('xliff 1.2 source/target attributes', () => {
 
 });
 
-describe('xliff additional attributes', () => {
-  test('xliff2js', (fn) => (done) => {
-    fn(fixtures.example_additional_attributes.xliff, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_additional_attributes.js);
-      done();
-    });
-  });
-  test('js2xliff', (fn) => (done) => {
-    fn(fixtures.example_additional_attributes.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_additional_attributes.xliff);
-      done();
-    });
-  });
-});
-
-describe('xliff 1.2 additional attributes', () => {
-  test('xliff12ToJs', (fn) => (done) => {
-    fn(fixtures.example_additional_attributes.xliff12, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_additional_attributes.js);
-      done();
-    });
-  });
-  test('jsToXliff12', (fn) => (done) => {
-    fn(fixtures.example_additional_attributes.js, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_additional_attributes.xliff12);
-      done();
-    });
-  });
-});
-
 describe('multi', () => {
 
   test('xliff2js', (fn) => (done) => {
@@ -269,4 +235,39 @@ describe('with notes', () => {
     });
   });
 
+});
+
+describe('with additional attributes', () => {
+  describe('xliff 2.0', () => {
+    test('xliff2js', (fn) => (done) => {
+      fn(fixtures.example_additional_attributes.xliff, (err, res) => {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_additional_attributes.js);
+        done();
+      });
+    });
+    test('js2xliff', (fn) => (done) => {
+      fn(fixtures.example_additional_attributes.js, (err, res) => {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_additional_attributes.xliff);
+        done();
+      });
+    });
+  });
+  describe('xliff 1.2', () => {
+    test('xliff12ToJs', (fn) => (done) => {
+      fn(fixtures.example_additional_attributes.xliff12, (err, res) => {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_additional_attributes.js);
+        done();
+      });
+    });
+    test('jsToXliff12', (fn) => (done) => {
+      fn(fixtures.example_additional_attributes.js, (err, res) => {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_additional_attributes.xliff12);
+        done();
+      });
+    });
+  });
 });

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -49,6 +49,11 @@ function xliff12ToJs(str, cb) {
 
         return unit;
       }, { source: '' });
+      const additionalAttributes = transUnit.attributes;
+      delete additionalAttributes.id;
+      if (Object.keys(additionalAttributes).length) {
+        Object.assign(file[key], {additionalAttributes});
+      }
 
       return file;
     }, {});

--- a/xliff2js.js
+++ b/xliff2js.js
@@ -51,6 +51,11 @@ function xliffToJs(str, cb) {
 
           return unit;
         }, { source: '', target: '' });
+        const additionalAttributes = unit.attributes;
+        delete additionalAttributes.id;
+        if (Object.keys(additionalAttributes).length) {
+          Object.assign(file[key], {additionalAttributes});
+        }
 
         return file;
       }, {});


### PR DESCRIPTION
For me it is important to add attributes to my `<trans-unit>`, e.g. `translate="no"` or `approved="yes"`. So I've added the possibility to pass `additionalAttributes` to your JavaScript files. These will be added to the `<trans-unit>` element of each item.
And of course, this also works the other way around, so your JavaScript file will have an `additionalAttributes` object, if there are any attributes set for `<trans-unit>` (excluding id)  :)