### PR TITLE
Adding support for google actions xliff elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vim
 node_modules
 .DS_Store
 .idea

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ createxliff(
           <source>XLIFF Data Manager</source>
           <target>XLIFF Daten Manager</target>
         </trans-unit>
+        <group id="group">
+          <trans-unit id="groupUnit">
+            <source>Group</source>
+            <target>Gruppe</target>
+          </trans-unit>
+        </group>
       </body>
     </file>
   </xliff>`
@@ -205,6 +211,14 @@ createxliff(
         "key.nested": {
           "source": "XLIFF Data Manager",
           "target": "XLIFF Daten Manager"
+        },
+        "group": {
+          "groupUnits":{
+            "groupUnit": {
+              "source": "Group",
+              "target": "Gruppe"
+            }
+          }
         }
       }
     },

--- a/test/fixtures/example_google_action.json
+++ b/test/fixtures/example_google_action.json
@@ -1,0 +1,103 @@
+{
+  "sourceLanguage": "de",
+  "targetLanguage": "de",
+  "resources": {
+    "agent.proto": {
+      "tu1": {
+        "source": "assistant app name",
+        "target": "assistant app name",
+        "note": "The default display name for this app (if there is not a translation available).",
+        "additionalAttributes": {
+          "resname": "assistantAppName"
+        }
+      },
+      "tu2": {
+        "source": "assistant app pronunciation",
+        "target": "assistant app pronunciation",
+        "note": "For triggering. This is the unique name for this app to directly invoke it within a voice (spoken) context.",
+        "additionalAttributes": {
+          "resname": "pronunciation"
+        }
+      },
+      "tu3": {
+        "source": "SHORT DESCRIPTION",
+        "target": "SHORT DESCRIPTION",
+        "note": "The default short description for the app (if there is not a translation available). This is limited to 80 characters.",
+        "additionalAttributes": {
+          "resname": "shortDescription"
+        }
+      },
+      "tu4": {
+        "source": "LONG DESCRIPTION",
+        "target": "LONG DESCRIPTION",
+        "note": "The default long description for the app (if there is not a translation available). This is limited to 4000 characters.",
+        "additionalAttributes": {
+          "resname": "fullDescription"
+        }
+      },
+      "tu5": {
+        "source": "Developer Name",
+        "target": "Developer Name",
+        "note": "The name of the publisher to be displayed to users.",
+        "additionalAttributes": {
+          "resname": "developerName"
+        }
+      },
+      "tu6": {
+        "source": "developer@example.com",
+        "target": "developer@example.com",
+        "note": "The contact email address for the publisher.",
+        "additionalAttributes": {
+          "resname": "email"
+        }
+      },
+      "tu7": {
+        "source": "https://example.com/terms",
+        "target": "https://example.com/terms",
+        "note": "The URL to the ToS (Terms of Service) for the app.",
+        "additionalAttributes": {
+          "resname": "linkToTermsOfService"
+        }
+      },
+      "tu8": {
+        "source": "female_1",
+        "target": "female_1",
+        "note": "The voice name for this app in the VUI (voice user interface) context. Example values supported: male_1, male_2, female_1, female_2",
+        "additionalAttributes": {
+          "resname": "assistantAppVoice"
+        }
+      },
+      "tu9": {
+        "source": "female_1",
+        "target": "female_1",
+        "note": "The external voice name for this app in the VUI (voice user interface) context. Does not contain locale information.",
+        "additionalAttributes": {
+          "resname": "assistantAppExternalVoiceName"
+        }
+      },
+      "tu10": {
+        "source": "https://example.com/privacy",
+        "target": "https://example.com/privacy",
+        "note": "The URL for the app's privacy policy.",
+        "additionalAttributes": {
+          "resname": "linkToPrivacyPolicy"
+        }
+      },
+      "grpId1": {
+        "additionalAttributes": {
+          "resname": "sampleInvocations"
+        },
+        "groupUnits": {
+          "tu11": {
+            "source": "Mit assistant app sprechen",
+            "target": "Mit assistant app sprechen",
+            "note": "Sample invocation phrase displayed as part of app description in the directory of all agents.",
+            "additionalAttributes": {
+              "resname": "sampleInvocations.1"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/example_google_action.xliff
+++ b/test/fixtures/example_google_action.xliff
@@ -1,0 +1,63 @@
+<xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="agent.proto" datatype="plaintext" source-language="de" target-language="de">
+    <body>
+      <trans-unit id="tu1" resname="assistantAppName">
+        <source xml:lang="de">assistant app name</source>
+        <target xml:lang="de">assistant app name</target>
+        <note>The default display name for this app (if there is not a translation available).</note>
+      </trans-unit>
+      <trans-unit id="tu2" resname="pronunciation">
+        <source xml:lang="de">assistant app pronunciation</source>
+        <target xml:lang="de">assistant app pronunciation</target>
+        <note>For triggering. This is the unique name for this app to directly invoke it within a voice (spoken) context.</note>
+      </trans-unit>
+      <trans-unit id="tu3" resname="shortDescription">
+        <source xml:lang="de">SHORT DESCRIPTION</source>
+        <target xml:lang="de">SHORT DESCRIPTION</target>
+        <note>The default short description for the app (if there is not a translation available). This is limited to 80 characters.</note>
+      </trans-unit>
+      <trans-unit id="tu4" resname="fullDescription">
+        <source xml:lang="de">LONG DESCRIPTION</source>
+        <target xml:lang="de">LONG DESCRIPTION</target>
+        <note>The default long description for the app (if there is not a translation available). This is limited to 4000 characters.</note>
+      </trans-unit>
+      <trans-unit id="tu5" resname="developerName">
+        <source xml:lang="de">Developer Name</source>
+        <target xml:lang="de">Developer Name</target>
+        <note>The name of the publisher to be displayed to users.</note>
+      </trans-unit>
+      <trans-unit id="tu6" resname="email">
+        <source xml:lang="de">developer@example.com</source>
+        <target xml:lang="de">developer@example.com</target>
+        <note>The contact email address for the publisher.</note>
+      </trans-unit>
+      <trans-unit id="tu7" resname="linkToTermsOfService">
+        <source xml:lang="de">https://example.com/terms</source>
+        <target xml:lang="de">https://example.com/terms</target>
+        <note>The URL to the ToS (Terms of Service) for the app.</note>
+      </trans-unit>
+      <trans-unit id="tu8" resname="assistantAppVoice">
+        <source xml:lang="de">female_1</source>
+        <target xml:lang="de">female_1</target>
+        <note>The voice name for this app in the VUI (voice user interface) context. Example values supported: male_1, male_2, female_1, female_2</note>
+      </trans-unit>
+      <trans-unit id="tu9" resname="assistantAppExternalVoiceName">
+        <source xml:lang="de">female_1</source>
+        <target xml:lang="de">female_1</target>
+        <note>The external voice name for this app in the VUI (voice user interface) context. Does not contain locale information.</note>
+      </trans-unit>
+      <trans-unit id="tu10" resname="linkToPrivacyPolicy">
+        <source xml:lang="de">https://example.com/privacy</source>
+        <target xml:lang="de">https://example.com/privacy</target>
+        <note>The URL for the app's privacy policy.</note>
+      </trans-unit>
+      <group id="grpId1" resname="sampleInvocations">
+        <trans-unit id="tu11" resname="sampleInvocations.1">
+          <source xml:lang="de">Mit assistant app sprechen</source>
+          <target xml:lang="de">Mit assistant app sprechen</target>
+          <note>Sample invocation phrase displayed as part of app description in the directory of all agents.</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -4,77 +4,39 @@ const path = require('path');
 module.exports = {
   example: {
     js: require('./example.json'),
-    xliff: fs
-      .readFileSync(path.join(__dirname, 'example.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
-    xliff12: fs
-      .readFileSync(path.join(__dirname, 'example12.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
+    xliff: fs.readFileSync(path.join(__dirname, 'example.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example12.xliff')).toString().replace(/\n$/, ''),
     js_source: require('./example_source.json'),
     js_target: require('./example_target.json')
   },
   example_source_attr: {
     // The JS should be the same as example.js
-    xliff12: fs
-      .readFileSync(path.join(__dirname, 'example_source_attr12.xliff'))
-      .toString()
-      .replace(/\n$/, '')
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_source_attr12.xliff')).toString().replace(/\n$/, ''),
   },
   example_multi: {
     js: require('./example_multi.json'),
-    xliff: fs
-      .readFileSync(path.join(__dirname, 'example_multi.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
-    xliff12: fs
-      .readFileSync(path.join(__dirname, 'example_multi12.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
+    xliff: fs.readFileSync(path.join(__dirname, 'example_multi.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_multi12.xliff')).toString().replace(/\n$/, ''),
     js_source: require('./example_multi_source.json'),
     js_target: require('./example_multi_target.json')
   },
   example_note: {
     js: require('./example_note.json'),
-    xliff: fs
-      .readFileSync(path.join(__dirname, 'example_note.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
-    xliff12: fs
-      .readFileSync(path.join(__dirname, 'example_note12.xliff'))
-      .toString()
-      .replace(/\n$/, '')
+    xliff: fs.readFileSync(path.join(__dirname, 'example_note.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_note12.xliff')).toString().replace(/\n$/, ''),
   },
   example_additional_attributes: {
     js: require('./example_additional_attributes'),
-    xliff: fs
-      .readFileSync(path.join(__dirname, 'example_additional_attributes.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
-    xliff12: fs
-      .readFileSync(
-        path.join(__dirname, 'example_additional_attributes12.xliff')
-      )
-      .toString()
-      .replace(/\n$/, '')
+    xliff: fs.readFileSync(path.join(__dirname, 'example_additional_attributes.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_additional_attributes12.xliff')).toString().replace(/\n$/, '')
   },
   example_angular: {
     js: require('./example_angular'),
-    xliff: fs
-      .readFileSync(path.join(__dirname, 'example_angular.xliff'))
-      .toString()
-      .replace(/\n$/, ''),
-    xliff12: fs
-      .readFileSync(path.join(__dirname, 'example_angular12.xliff'))
-      .toString()
-      .replace(/\n$/, '')
+    xliff: fs.readFileSync(path.join(__dirname, 'example_angular.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_angular12.xliff')).toString().replace(/\n$/, '')
   },
   example_google: {
     js: require('./example_google_action'),
-    xliff12: fs
-      .readFileSync(path.join(__dirname, 'example_google_action.xliff'))
-      .toString()
-      .replace(/\n$/, '')
+    xliff12: fs.readFileSync(path.join(__dirname, 'example_google_action.xliff')).toString().replace(/\n$/, ''),
   }
 };

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -4,35 +4,77 @@ const path = require('path');
 module.exports = {
   example: {
     js: require('./example.json'),
-    xliff: fs.readFileSync(path.join(__dirname, 'example.xliff')).toString().replace(/\n$/, ''),
-    xliff12: fs.readFileSync(path.join(__dirname, 'example12.xliff')).toString().replace(/\n$/, ''),
+    xliff: fs
+      .readFileSync(path.join(__dirname, 'example.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
+    xliff12: fs
+      .readFileSync(path.join(__dirname, 'example12.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
     js_source: require('./example_source.json'),
     js_target: require('./example_target.json')
   },
   example_source_attr: {
     // The JS should be the same as example.js
-    xliff12: fs.readFileSync(path.join(__dirname, 'example_source_attr12.xliff')).toString().replace(/\n$/, ''),
+    xliff12: fs
+      .readFileSync(path.join(__dirname, 'example_source_attr12.xliff'))
+      .toString()
+      .replace(/\n$/, '')
   },
   example_multi: {
     js: require('./example_multi.json'),
-    xliff: fs.readFileSync(path.join(__dirname, 'example_multi.xliff')).toString().replace(/\n$/, ''),
-    xliff12: fs.readFileSync(path.join(__dirname, 'example_multi12.xliff')).toString().replace(/\n$/, ''),
+    xliff: fs
+      .readFileSync(path.join(__dirname, 'example_multi.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
+    xliff12: fs
+      .readFileSync(path.join(__dirname, 'example_multi12.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
     js_source: require('./example_multi_source.json'),
     js_target: require('./example_multi_target.json')
   },
   example_note: {
     js: require('./example_note.json'),
-    xliff: fs.readFileSync(path.join(__dirname, 'example_note.xliff')).toString().replace(/\n$/, ''),
-    xliff12: fs.readFileSync(path.join(__dirname, 'example_note12.xliff')).toString().replace(/\n$/, ''),
+    xliff: fs
+      .readFileSync(path.join(__dirname, 'example_note.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
+    xliff12: fs
+      .readFileSync(path.join(__dirname, 'example_note12.xliff'))
+      .toString()
+      .replace(/\n$/, '')
   },
   example_additional_attributes: {
     js: require('./example_additional_attributes'),
-    xliff: fs.readFileSync(path.join(__dirname, 'example_additional_attributes.xliff')).toString().replace(/\n$/, ''),
-    xliff12: fs.readFileSync(path.join(__dirname, 'example_additional_attributes12.xliff')).toString().replace(/\n$/, '')
+    xliff: fs
+      .readFileSync(path.join(__dirname, 'example_additional_attributes.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
+    xliff12: fs
+      .readFileSync(
+        path.join(__dirname, 'example_additional_attributes12.xliff')
+      )
+      .toString()
+      .replace(/\n$/, '')
   },
   example_angular: {
     js: require('./example_angular'),
-    xliff: fs.readFileSync(path.join(__dirname, 'example_angular.xliff')).toString().replace(/\n$/, ''),
-    xliff12: fs.readFileSync(path.join(__dirname, 'example_angular12.xliff')).toString().replace(/\n$/, '')
+    xliff: fs
+      .readFileSync(path.join(__dirname, 'example_angular.xliff'))
+      .toString()
+      .replace(/\n$/, ''),
+    xliff12: fs
+      .readFileSync(path.join(__dirname, 'example_angular12.xliff'))
+      .toString()
+      .replace(/\n$/, '')
+  },
+  example_google: {
+    js: require('./example_google_action'),
+    xliff12: fs
+      .readFileSync(path.join(__dirname, 'example_google_action.xliff'))
+      .toString()
+      .replace(/\n$/, '')
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,6 @@ function test(what, t) {
 }
 
 describe('single', () => {
-
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example.xliff, (err, res) => {
       expect(err).not.to.be.ok();
@@ -27,23 +26,29 @@ describe('single', () => {
   });
 
   describe('angular', () => {
-
     test('xliff12ToJs', (fn) => (done) => {
-      fn(fixtures.example_angular.xliff12, { namespace: 'example_angular' }, (err, res) => {
-        expect(err).not.to.be.ok();
-        expect(res).to.eql(fixtures.example_angular.js);
-        done();
-      });
+      fn(
+        fixtures.example_angular.xliff12,
+        { namespace: 'example_angular' },
+        (err, res) => {
+          expect(err).not.to.be.ok();
+          expect(res).to.eql(fixtures.example_angular.js);
+          done();
+        }
+      );
     });
 
     test('xliff2js', (fn) => (done) => {
-      fn(fixtures.example_angular.xliff, { namespace: 'example_angular' }, (err, res) => {
-        expect(err).not.to.be.ok();
-        expect(res).to.eql(fixtures.example_angular.js);
-        done();
-      });
+      fn(
+        fixtures.example_angular.xliff,
+        { namespace: 'example_angular' },
+        (err, res) => {
+          expect(err).not.to.be.ok();
+          expect(res).to.eql(fixtures.example_angular.js);
+          done();
+        }
+      );
     });
-
   });
 
   test('js2xliff', (fn) => (done) => {
@@ -65,7 +70,9 @@ describe('single', () => {
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].target);
+      expect(res['key.nested']).to.eql(
+        fixtures.example.js.resources.namespace1['key.nested'].target
+      );
       done();
     });
   });
@@ -73,7 +80,9 @@ describe('single', () => {
   test('sourceOfjs', (fn) => (done) => {
     fn(fixtures.example.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].source);
+      expect(res['key.nested']).to.eql(
+        fixtures.example.js.resources.namespace1['key.nested'].source
+      );
       done();
     });
   });
@@ -122,11 +131,9 @@ describe('single', () => {
       }
     );
   });
-
 });
 
 describe('xliff 1.2 source/target attributes', () => {
-
   test('xliff12ToJs', (fn) => (done) => {
     fn(fixtures.example_source_attr.xliff12, (err, res) => {
       expect(err).not.to.be.ok();
@@ -134,11 +141,27 @@ describe('xliff 1.2 source/target attributes', () => {
       done();
     });
   });
+});
 
+describe('Google Actions Xliff', () => {
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_google.xliff12, {xmlLangAttr: true}, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_google.js);
+      done();
+    });
+  });
+
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example_google.js, {xmlLangAttr: true}, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_google.xliff12);
+      done();
+    });
+  });
 });
 
 describe('multi', () => {
-
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example_multi.xliff, (err, res) => {
       expect(err).not.to.be.ok();
@@ -166,8 +189,12 @@ describe('multi', () => {
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example_multi.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].target);
-      expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].target);
+      expect(res.namespace1['key.nested']).to.eql(
+        fixtures.example_multi.js.resources.namespace1['key.nested'].target
+      );
+      expect(res.namespace2['k']).to.eql(
+        fixtures.example_multi.js.resources.namespace2['k'].target
+      );
       done();
     });
   });
@@ -175,8 +202,12 @@ describe('multi', () => {
   test('sourceOfjs', (fn) => (done) => {
     fn(fixtures.example_multi.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].source);
-      expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].source);
+      expect(res.namespace1['key.nested']).to.eql(
+        fixtures.example_multi.js.resources.namespace1['key.nested'].source
+      );
+      expect(res.namespace2['k']).to.eql(
+        fixtures.example_multi.js.resources.namespace2['k'].source
+      );
       done();
     });
   });
@@ -208,11 +239,9 @@ describe('multi', () => {
       }
     );
   });
-
 });
 
 describe('with notes', () => {
-
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example_note.xliff, (err, res) => {
       expect(err).not.to.be.ok();
@@ -240,8 +269,12 @@ describe('with notes', () => {
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example_note.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(fixtures.example_note.js.resources.namespace1['key.nested'].target);
-      expect(res.namespace2['k']).to.eql(fixtures.example_note.js.resources.namespace2['k'].target);
+      expect(res.namespace1['key.nested']).to.eql(
+        fixtures.example_note.js.resources.namespace1['key.nested'].target
+      );
+      expect(res.namespace2['k']).to.eql(
+        fixtures.example_note.js.resources.namespace2['k'].target
+      );
       done();
     });
   });
@@ -249,12 +282,15 @@ describe('with notes', () => {
   test('sourceOfjs', (fn) => (done) => {
     fn(fixtures.example_note.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(fixtures.example_note.js.resources.namespace1['key.nested'].source);
-      expect(res.namespace2['k']).to.eql(fixtures.example_note.js.resources.namespace2['k'].source);
+      expect(res.namespace1['key.nested']).to.eql(
+        fixtures.example_note.js.resources.namespace1['key.nested'].source
+      );
+      expect(res.namespace2['k']).to.eql(
+        fixtures.example_note.js.resources.namespace2['k'].source
+      );
       done();
     });
   });
-
 });
 
 describe('with additional attributes', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ function test(what, t) {
 }
 
 describe('single', () => {
+
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example.xliff, (err, res) => {
       expect(err).not.to.be.ok();
@@ -26,29 +27,23 @@ describe('single', () => {
   });
 
   describe('angular', () => {
+
     test('xliff12ToJs', (fn) => (done) => {
-      fn(
-        fixtures.example_angular.xliff12,
-        { namespace: 'example_angular' },
-        (err, res) => {
-          expect(err).not.to.be.ok();
-          expect(res).to.eql(fixtures.example_angular.js);
-          done();
-        }
-      );
+      fn(fixtures.example_angular.xliff12, { namespace: 'example_angular' }, (err, res) => {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_angular.js);
+        done();
+      });
     });
 
     test('xliff2js', (fn) => (done) => {
-      fn(
-        fixtures.example_angular.xliff,
-        { namespace: 'example_angular' },
-        (err, res) => {
-          expect(err).not.to.be.ok();
-          expect(res).to.eql(fixtures.example_angular.js);
-          done();
-        }
-      );
+      fn(fixtures.example_angular.xliff, { namespace: 'example_angular' }, (err, res) => {
+        expect(err).not.to.be.ok();
+        expect(res).to.eql(fixtures.example_angular.js);
+        done();
+      });
     });
+
   });
 
   test('js2xliff', (fn) => (done) => {
@@ -70,9 +65,7 @@ describe('single', () => {
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res['key.nested']).to.eql(
-        fixtures.example.js.resources.namespace1['key.nested'].target
-      );
+      expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].target);
       done();
     });
   });
@@ -80,9 +73,7 @@ describe('single', () => {
   test('sourceOfjs', (fn) => (done) => {
     fn(fixtures.example.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res['key.nested']).to.eql(
-        fixtures.example.js.resources.namespace1['key.nested'].source
-      );
+      expect(res['key.nested']).to.eql(fixtures.example.js.resources.namespace1['key.nested'].source);
       done();
     });
   });
@@ -131,9 +122,11 @@ describe('single', () => {
       }
     );
   });
+
 });
 
 describe('xliff 1.2 source/target attributes', () => {
+
   test('xliff12ToJs', (fn) => (done) => {
     fn(fixtures.example_source_attr.xliff12, (err, res) => {
       expect(err).not.to.be.ok();
@@ -141,27 +134,11 @@ describe('xliff 1.2 source/target attributes', () => {
       done();
     });
   });
-});
 
-describe('Google Actions Xliff', () => {
-  test('xliff12ToJs', (fn) => (done) => {
-    fn(fixtures.example_google.xliff12, {xmlLangAttr: true}, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_google.js);
-      done();
-    });
-  });
-
-  test('jsToXliff12', (fn) => (done) => {
-    fn(fixtures.example_google.js, {xmlLangAttr: true}, (err, res) => {
-      expect(err).not.to.be.ok();
-      expect(res).to.eql(fixtures.example_google.xliff12);
-      done();
-    });
-  });
 });
 
 describe('multi', () => {
+
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example_multi.xliff, (err, res) => {
       expect(err).not.to.be.ok();
@@ -189,12 +166,8 @@ describe('multi', () => {
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example_multi.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(
-        fixtures.example_multi.js.resources.namespace1['key.nested'].target
-      );
-      expect(res.namespace2['k']).to.eql(
-        fixtures.example_multi.js.resources.namespace2['k'].target
-      );
+      expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].target);
+      expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].target);
       done();
     });
   });
@@ -202,12 +175,8 @@ describe('multi', () => {
   test('sourceOfjs', (fn) => (done) => {
     fn(fixtures.example_multi.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(
-        fixtures.example_multi.js.resources.namespace1['key.nested'].source
-      );
-      expect(res.namespace2['k']).to.eql(
-        fixtures.example_multi.js.resources.namespace2['k'].source
-      );
+      expect(res.namespace1['key.nested']).to.eql(fixtures.example_multi.js.resources.namespace1['key.nested'].source);
+      expect(res.namespace2['k']).to.eql(fixtures.example_multi.js.resources.namespace2['k'].source);
       done();
     });
   });
@@ -239,9 +208,11 @@ describe('multi', () => {
       }
     );
   });
+
 });
 
 describe('with notes', () => {
+
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example_note.xliff, (err, res) => {
       expect(err).not.to.be.ok();
@@ -269,12 +240,8 @@ describe('with notes', () => {
   test('targetOfjs', (fn) => (done) => {
     fn(fixtures.example_note.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(
-        fixtures.example_note.js.resources.namespace1['key.nested'].target
-      );
-      expect(res.namespace2['k']).to.eql(
-        fixtures.example_note.js.resources.namespace2['k'].target
-      );
+      expect(res.namespace1['key.nested']).to.eql(fixtures.example_note.js.resources.namespace1['key.nested'].target);
+      expect(res.namespace2['k']).to.eql(fixtures.example_note.js.resources.namespace2['k'].target);
       done();
     });
   });
@@ -282,15 +249,12 @@ describe('with notes', () => {
   test('sourceOfjs', (fn) => (done) => {
     fn(fixtures.example_note.js, (err, res) => {
       expect(err).not.to.be.ok();
-      expect(res.namespace1['key.nested']).to.eql(
-        fixtures.example_note.js.resources.namespace1['key.nested'].source
-      );
-      expect(res.namespace2['k']).to.eql(
-        fixtures.example_note.js.resources.namespace2['k'].source
-      );
+      expect(res.namespace1['key.nested']).to.eql(fixtures.example_note.js.resources.namespace1['key.nested'].source);
+      expect(res.namespace2['k']).to.eql(fixtures.example_note.js.resources.namespace2['k'].source);
       done();
     });
   });
+
 });
 
 describe('with additional attributes', () => {
@@ -324,6 +288,24 @@ describe('with additional attributes', () => {
         expect(res).to.eql(fixtures.example_additional_attributes.xliff12);
         done();
       });
+    });
+  });
+});
+
+describe('Google Actions Xliff', () => {
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_google.xliff12, {xmlLangAttr: true}, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_google.js);
+      done();
+    });
+  });
+
+  test('jsToXliff12', (fn) => (done) => {
+    fn(fixtures.example_google.js, {xmlLangAttr: true}, (err, res) => {
+      expect(err).not.to.be.ok();
+      expect(res).to.eql(fixtures.example_google.xliff12);
+      done();
     });
   });
 });

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -40,28 +40,18 @@ function xliff12ToJs(str, options, cb) {
 
     const body = file.elements.find((e) => e.name === 'body');
     body.elements = body.elements || [];
-    const transUnits = body.elements.filter((transunit) => transunit.type !== 'comment');
+    const transUnits = body.elements.filter(
+      (transunit) => transunit.type !== 'comment'
+    );
 
     // namespace
     resources[namespace] = transUnits.reduce((file, transUnit) => {
       const key = transUnit.attributes.id;
-
-      // source, target, note
-      file[key] = transUnit.elements.reduce((unit, element) => {
-        switch (element.name) {
-          case 'source':
-          case 'target':
-          case 'note':
-            unit[element.name] = extractValue(element.elements, ElementTypes12);
-            break;
-        }
-
-        return unit;
-      }, { source: '' });
-      const additionalAttributes = transUnit.attributes;
-      delete additionalAttributes.id;
-      if (Object.keys(additionalAttributes).length) {
-        Object.assign(file[key], {additionalAttributes});
+      const childs = transUnit.elements.filter((e) => e.name === 'trans-unit');
+      if (childs.length) {
+        file[key] = createGroupTag(transUnit, childs);
+      } else {
+        file[key] = createTransUnitTag(transUnit);
       }
 
       return file;
@@ -72,6 +62,47 @@ function xliff12ToJs(str, options, cb) {
 
   if (cb) return cb(null, result);
   return result;
+}
+
+function createTransUnitTag(transUnit) {
+  const additionalAttributes = transUnit.attributes;
+  delete additionalAttributes.id;
+
+  const jsUnit = transUnit.elements.reduce((unit, element) => {
+    switch (element.name) {
+      case 'source':
+      case 'target':
+      case 'note':
+        unit[element.name] = extractValue(element.elements, ElementTypes12);
+        break;
+    }
+
+    return unit;
+  }, {});
+
+  if (Object.keys(additionalAttributes).length) {
+    Object.assign(jsUnit, { additionalAttributes });
+  }
+  return jsUnit;
+}
+
+function createGroupTag(groupUnit, childs) {
+  const additionalAttributes = groupUnit.attributes;
+  delete additionalAttributes.id;
+
+  const jsGroupUnit = {
+    groupUnits: childs.reduce((groupFile, groupTransUnit) => {
+      const key = groupTransUnit.attributes.id;
+      groupFile[key] = createTransUnitTag(groupTransUnit);
+      return groupFile;
+    }, {})
+  };
+
+  if (Object.keys(additionalAttributes).length) {
+    Object.assign(jsGroupUnit, { additionalAttributes });
+  }
+
+  return jsGroupUnit;
 }
 
 module.exports = xliff12ToJs;

--- a/xliff12ToJs.js
+++ b/xliff12ToJs.js
@@ -65,9 +65,6 @@ function xliff12ToJs(str, options, cb) {
 }
 
 function createTransUnitTag(transUnit) {
-  const additionalAttributes = transUnit.attributes;
-  delete additionalAttributes.id;
-
   const jsUnit = transUnit.elements.reduce((unit, element) => {
     switch (element.name) {
       case 'source':
@@ -78,18 +75,12 @@ function createTransUnitTag(transUnit) {
     }
 
     return unit;
-  }, {});
+  }, {source: ''});
 
-  if (Object.keys(additionalAttributes).length) {
-    Object.assign(jsUnit, { additionalAttributes });
-  }
-  return jsUnit;
+  return addAdditionalAttributes(jsUnit, transUnit.attributes);
 }
 
 function createGroupTag(groupUnit, childs) {
-  const additionalAttributes = groupUnit.attributes;
-  delete additionalAttributes.id;
-
   const jsGroupUnit = {
     groupUnits: childs.reduce((groupFile, groupTransUnit) => {
       const key = groupTransUnit.attributes.id;
@@ -98,11 +89,18 @@ function createGroupTag(groupUnit, childs) {
     }, {})
   };
 
+  return addAdditionalAttributes(jsGroupUnit, groupUnit.attributes);
+}
+
+function addAdditionalAttributes(jsUnit, attributes) {
+  const additionalAttributes = attributes;
+  delete additionalAttributes.id;
+
   if (Object.keys(additionalAttributes).length) {
-    Object.assign(jsGroupUnit, { additionalAttributes });
+    Object.assign(jsUnit, { additionalAttributes });
   }
 
-  return jsGroupUnit;
+  return jsUnit;
 }
 
 module.exports = xliff12ToJs;

--- a/xml-js/xmlToObject.js
+++ b/xml-js/xmlToObject.js
@@ -1,15 +1,24 @@
-const tagToElementType = require('../inline-elements/typeToTagMaps').tagToElementType;
+const tagToElementType = require('../inline-elements/typeToTagMaps')
+  .tagToElementType;
 
 function extractValue(valueElements, elementTypeInfo) {
-  if (valueElements === undefined || valueElements === null || valueElements === '') {
+  if (
+    valueElements === undefined ||
+    valueElements === null ||
+    valueElements === ''
+  ) {
     return '';
   }
 
   if (Array.isArray(valueElements) && valueElements.length > 1) {
-    return valueElements.map((valueElement) => extractValue(valueElement, elementTypeInfo));
+    return valueElements.map((valueElement) =>
+      extractValue(valueElement, elementTypeInfo)
+    );
   }
 
-  const valueElement = Array.isArray(valueElements) ? valueElements[0] || '' : valueElements;
+  const valueElement = Array.isArray(valueElements)
+    ? valueElements[0] || ''
+    : valueElements;
 
   // text node
   if (valueElement.type === 'text') {

--- a/xml-js/xmlToObject.js
+++ b/xml-js/xmlToObject.js
@@ -1,24 +1,15 @@
-const tagToElementType = require('../inline-elements/typeToTagMaps')
-  .tagToElementType;
+const tagToElementType = require('../inline-elements/typeToTagMaps').tagToElementType;
 
 function extractValue(valueElements, elementTypeInfo) {
-  if (
-    valueElements === undefined ||
-    valueElements === null ||
-    valueElements === ''
-  ) {
+  if (valueElements === undefined || valueElements === null || valueElements === '') {
     return '';
   }
 
   if (Array.isArray(valueElements) && valueElements.length > 1) {
-    return valueElements.map((valueElement) =>
-      extractValue(valueElement, elementTypeInfo)
-    );
+    return valueElements.map((valueElement) => extractValue(valueElement, elementTypeInfo));
   }
 
-  const valueElement = Array.isArray(valueElements)
-    ? valueElements[0] || ''
-    : valueElements;
+  const valueElement = Array.isArray(valueElements) ? valueElements[0] || '' : valueElements;
 
   // text node
   if (valueElement.type === 'text') {


### PR DESCRIPTION
Related to #26 

At this point the implementation is working and all of the existing functionality continues to work correctly (according to the tests). Would very much appreciate comments, will of course also be adding some documentation to the README

The proposal is for the JSON to look like the following
```json
{
  "resources": {
      "grpId1": {
        "additionalAttributes": {
          "resname": "sampleInvocations"
        },
        "groupUnits": {
          "tu11": {
            "source": "Mit assistant app sprechen",
            "target": "Mit assistant app sprechen",
            "note": "Sample invocation phrase displayed as part of app description in the directory of all agents.",
            "additionalAttributes": {
              "resname": "sampleInvocations.1"
            }
          }
        }
      }
    }
  }
}
````

Which would in turn generate an xml like
```xml
<group id="grpId1" resname="sampleInvocations">
  <trans-unit id="tu11" resname="sampleInvocations.1">
    <source xml:lang="de">Mit assistant app sprechen</source>
    <target xml:lang="de">Mit assistant app sprechen</target>
    <note>Sample invocation phrase displayed as part of app description in the directory of all agents.</note>
  </trans-unit>
</group>
```

Also, seems like the autoformat in my vim config did a little too much, let me know if that's fine or if i should just try and get a smaller diff, still passes all the `npm lint` checks