### PR TITLE
Handle empty xliff files

### DIFF
--- a/lib/xliff12ToJs.js
+++ b/lib/xliff12ToJs.js
@@ -25,7 +25,7 @@ const xliff12ToJsClb = (str, options, cb) => {
   }
 
   const xliffRoot = xmlObj.elements.find((ele) => ele.name === 'xliff')
-  
+
   if (xliffRoot.elements && xliffRoot.elements.length) {
     const srcLang = xliffRoot.elements[0].attributes['source-language']
     const trgLang = xliffRoot.elements[0].attributes['target-language']

--- a/test/fixtures/example_empty12.xliff
+++ b/test/fixtures/example_empty12.xliff
@@ -1,0 +1,1 @@
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"></xliff>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -63,5 +63,8 @@ module.exports = {
   example_ignorable: {
     js: require('./example_ignorable'),
     xliff: fixNewLines(fs.readFileSync(path.join(__dirname, 'example_ignorable.xliff')).toString())
+  },
+  example_empty:{
+    xliff12: fixNewLines(fs.readFileSync(path.join(__dirname, 'example_empty12.xliff')).toString())
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -201,6 +201,17 @@ describe('xliff 1.2 source/target attributes', () => {
   })
 })
 
+describe('xliff 1.2 empty file', () => {
+  test('xliff12ToJs', (fn) => (done) => {
+    fn(fixtures.example_empty.xliff12, (err, res) => {
+      expect(err).not.to.be.ok()
+      expect(res).to.eql({ resources: {} })
+      done()
+    })
+  })
+})
+
+
 describe('multi', () => {
   test('xliff2js', (fn) => (done) => {
     fn(fixtures.example_multi.xliff, (err, res) => {


### PR DESCRIPTION
:wave: 

I got an issue when reading an empty xliff file, the lib crashes 
```
TypeError: Cannot read properties of undefined (reading '0')                                                      
    at xliff12ToJsClb (file://node_modules/xliff/esm/xliff12ToJs.js:32:35)
    at file:////node_modules/xliff/esm/xliff12ToJs.js:124:14                
    at new Promise (<anonymous>)                                                                                  
    at xliff12ToJs (file://node_modules/xliff/esm/xliff12ToJs.js:123:12)  ```
```   
ex:

```xliff
<?xml version="1.0" encoding="UTF-8"?>                                      
<xliff 
  xmlns="urn:oasis:names:tc:xliff:document:1.2" 
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  version="1.2" 
  xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd"></xliff>
  
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test` _158 passing (187ms)_
- [x] tests are included
- [x] documentation is changed or added